### PR TITLE
feat(db): TypeScript interfaces + Dexie schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,14 @@
       "name": "exam-creator",
       "version": "0.1.0",
       "dependencies": {
+        "dexie": "^4.3.0",
         "vue": "^3.4.0",
         "vue-router": "^4.3.0"
       },
       "devDependencies": {
         "@vitejs/plugin-vue": "^5.0.0",
         "@vue/test-utils": "^2.4.0",
+        "fake-indexeddb": "^6.2.5",
         "jsdom": "^24.0.0",
         "typescript": "^5.4.0",
         "vite": "^5.2.0",
@@ -3773,6 +3775,12 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/dexie": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/dexie/-/dexie-4.3.0.tgz",
+      "integrity": "sha512-5EeoQpJvMKHe6zWt/FSIIuRa3CWlZeIl6zKXt+Lz7BU6RoRRLgX9dZEynRfXrkLcldKYCBiz7xekTEylnie1Ug==",
+      "license": "Apache-2.0"
+    },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
@@ -4094,6 +4102,16 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/fast-deep-equal": {

--- a/package.json
+++ b/package.json
@@ -10,12 +10,14 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "dexie": "^4.3.0",
     "vue": "^3.4.0",
     "vue-router": "^4.3.0"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.0.0",
     "@vue/test-utils": "^2.4.0",
+    "fake-indexeddb": "^6.2.5",
     "jsdom": "^24.0.0",
     "typescript": "^5.4.0",
     "vite": "^5.2.0",

--- a/src/__tests__/db.spec.ts
+++ b/src/__tests__/db.spec.ts
@@ -1,0 +1,67 @@
+import 'fake-indexeddb/auto'
+import { describe, it, expect } from 'vitest'
+
+describe('types/index', () => {
+  it('exports all interfaces and union types without TS errors', async () => {
+    const types = await import('@/types')
+    expect(types).toBeDefined()
+  })
+})
+
+describe('db/db', () => {
+  it('ExamDB instantiates without throwing', async () => {
+    const { db } = await import('@/db/db')
+    expect(db).toBeDefined()
+  })
+
+  it('has all four table names on the instance', async () => {
+    const { db } = await import('@/db/db')
+    expect(db.questions).toBeDefined()
+    expect(db.topics).toBeDefined()
+    expect(db.sessions).toBeDefined()
+    expect(db.settings).toBeDefined()
+  })
+
+  it('questions table has correct indexes', async () => {
+    const { db } = await import('@/db/db')
+    const schema = (db as any)._dbSchema
+    const qSchema = schema.questions
+    expect(qSchema.primKey.name).toBe('id')
+    expect(qSchema.primKey.auto).toBe(true)
+    const idxNames = qSchema.indexes.map((i: any) => i.name)
+    expect(idxNames).toContain('topicId')
+    expect(idxNames).toContain('errorCount')
+    expect(idxNames).toContain('lastSeenAt')
+  })
+
+  it('topics table has unique index on topicId', async () => {
+    const { db } = await import('@/db/db')
+    const schema = (db as any)._dbSchema
+    const tSchema = schema.topics
+    expect(tSchema.primKey.name).toBe('id')
+    expect(tSchema.primKey.auto).toBe(true)
+    const topicIdIdx = tSchema.indexes.find((i: any) => i.name === 'topicId')
+    expect(topicIdIdx).toBeDefined()
+    expect(topicIdIdx.unique).toBe(true)
+  })
+
+  it('sessions table has correct indexes', async () => {
+    const { db } = await import('@/db/db')
+    const schema = (db as any)._dbSchema
+    const sSchema = schema.sessions
+    expect(sSchema.primKey.name).toBe('id')
+    expect(sSchema.primKey.auto).toBe(true)
+    const idxNames = sSchema.indexes.map((i: any) => i.name)
+    expect(idxNames).toContain('startedAt')
+    expect(idxNames).toContain('completedAt')
+    expect(idxNames).toContain('mode')
+  })
+
+  it('settings table has unique key index', async () => {
+    const { db } = await import('@/db/db')
+    const schema = (db as any)._dbSchema
+    const setSchema = schema.settings
+    expect(setSchema.primKey.name).toBe('key')
+    expect(setSchema.primKey.unique).toBe(true)
+  })
+})

--- a/src/db/db.ts
+++ b/src/db/db.ts
@@ -1,0 +1,21 @@
+import Dexie, { type Table } from 'dexie'
+import type { Question, Topic, Session, Setting } from '@/types'
+
+class ExamDB extends Dexie {
+  questions!: Table<Question>
+  topics!: Table<Topic>
+  sessions!: Table<Session>
+  settings!: Table<Setting>
+
+  constructor() {
+    super('ExamDB')
+    this.version(1).stores({
+      questions: '++id, topicId, errorCount, lastSeenAt',
+      topics: '++id, &topicId',
+      sessions: '++id, startedAt, completedAt, mode',
+      settings: '&key',
+    })
+  }
+}
+
+export const db = new ExamDB()

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,59 @@
+export type QuestionSource = 'seed' | 'generated'
+export type SessionMode = 'review' | 'difficult' | 'new' | 'mixed'
+export type FeedbackMode = 'study' | 'exam'
+export type SettingKey = 'apiKey' | 'defaultQuestionCount' | 'defaultMode'
+
+export interface Question {
+  id?: number
+  topicId: string
+  text: string
+  options: string[]
+  correctIndex: number
+  explanation: string
+  source: QuestionSource
+  errorCount: number
+  lastSeenAt: number | null
+  createdAt: number
+}
+
+export interface Topic {
+  id?: number
+  topicId: string
+  name: string
+  rawScore: number
+  lastReviewedAt: number | null
+  totalSessions: number
+}
+
+export interface Session {
+  id?: number
+  startedAt: number
+  completedAt: number | null
+  mode: SessionMode
+  topicIds: string[]
+  totalQuestions: number
+  correctCount: number
+  durationMs: number
+}
+
+export interface Setting {
+  key: SettingKey
+  value: string
+}
+
+export interface SessionConfig {
+  topicIds: string[]
+  mode: SessionMode
+  questionCount: number
+  feedbackMode: FeedbackMode
+  timerEnabled: boolean
+  timerSeconds: number
+}
+
+export interface GeneratedQuestion {
+  topicId: string
+  text: string
+  options: string[]
+  correctIndex: number
+  explanation: string
+}


### PR DESCRIPTION
## 🚀 Feature
- Add canonical TypeScript interfaces/union types and Dexie IndexedDB schema for ExamDB.

### 📄 Summary
- Introduces `src/types/index.ts` as the single source of truth for all domain types used across the app.
- Implements `src/db/db.ts` with `ExamDB` (Dexie subclass) defining four IndexedDB stores with correct index signatures.
- Installs `dexie` and `fake-indexeddb` (dev) dependencies.

Closes #2

### 🌟 What's New
- `src/types/index.ts`: exports `QuestionSource`, `SessionMode`, `FeedbackMode`, `SettingKey` union types and `Question`, `Topic`, `Session`, `Setting`, `SessionConfig`, `GeneratedQuestion` interfaces
- `src/db/db.ts`: `ExamDB` class with `questions`, `topics`, `sessions`, `settings` tables; `db` singleton exported
- `src/__tests__/db.spec.ts`: TDD tests covering instantiation, table presence, and index correctness

### 🧪 How to Test
- `npm run test` — all 14 tests pass (7 new db.spec.ts tests)
- `npm run build` — clean build with no TypeScript errors

### 🖼️ UI Changes (if any)
None.

### 📌 Checklist
- [x] Feature works as expected
- [x] Unit/integration tests added (if applicable)
- [x] Updated relevant documentation
- [ ] Verified in staging (if applicable)