### PR TITLE
feat(settings): settings data layer (Pinia + IndexedDB)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "dexie": "^4.3.0",
+        "pinia": "^3.0.4",
         "vue": "^3.4.0",
         "vue-router": "^4.3.0"
       },
@@ -2945,6 +2946,30 @@
       "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
       "license": "MIT"
     },
+    "node_modules/@vue/devtools-kit": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.9.tgz",
+      "integrity": "sha512-PyQ6odHSgiDVd4hnTP+aDk2X4gl2HmLDfiyEnn3/oV+ckFDuswRs4IbBT7vacMuGdwY/XemxBoh302ctbsptuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-shared": "^7.7.9",
+        "birpc": "^2.3.0",
+        "hookable": "^5.5.3",
+        "mitt": "^3.0.1",
+        "perfect-debounce": "^1.0.0",
+        "speakingurl": "^14.0.1",
+        "superjson": "^2.2.2"
+      }
+    },
+    "node_modules/@vue/devtools-shared": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.9.tgz",
+      "integrity": "sha512-iWAb0v2WYf0QWmxCGy0seZNDPdO3Sp5+u78ORnyeonS6MT4PC7VPrryX2BpMJrwlDeaZ6BD4vP4XKjK0SZqaeA==",
+      "license": "MIT",
+      "dependencies": {
+        "rfdc": "^1.4.1"
+      }
+    },
     "node_modules/@vue/language-core": {
       "version": "2.2.12",
       "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-2.2.12.tgz",
@@ -3298,6 +3323,15 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/birpc": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
+      "integrity": "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
@@ -3539,6 +3573,21 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/copy-anything": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-4.0.5.tgz",
+      "integrity": "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-what": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
     },
     "node_modules/core-js-compat": {
       "version": "3.49.0",
@@ -4578,6 +4627,12 @@
         "he": "bin/he"
       }
     },
+    "node_modules/hookable": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
+      "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
+      "license": "MIT"
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
@@ -5087,6 +5142,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-what": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-5.5.0.tgz",
+      "integrity": "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
     "node_modules/isarray": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
@@ -5441,6 +5508,12 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "license": "MIT"
+    },
     "node_modules/mlly": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
@@ -5724,6 +5797,12 @@
         "node": "*"
       }
     },
+    "node_modules/perfect-debounce": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
+      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -5741,6 +5820,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pinia": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pinia/-/pinia-3.0.4.tgz",
+      "integrity": "sha512-l7pqLUFTI/+ESXn6k3nu30ZIzW5E2WZF/LaHJEpoq6ElcLD+wduZoB2kBN19du6K/4FDpPMazY2wJr+IndBtQw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^7.7.7"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.5.0",
+        "vue": "^3.5.11"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pinia/node_modules/@vue/devtools-api": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.9.tgz",
+      "integrity": "sha512-kIE8wvwlcZ6TJTbNeU2HQNtaxLx3a84aotTITUuL/4bzfPxzajGBOoqjMhwZJ8L9qFYDU/lAYMEEm11dnZOD6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-kit": "^7.7.9"
       }
     },
     "node_modules/pkg-types": {
@@ -6021,6 +6130,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "license": "MIT"
     },
     "node_modules/rollup": {
       "version": "4.60.0",
@@ -6452,6 +6567,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/speakingurl": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
+      "integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -6720,6 +6844,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/superjson": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz",
+      "integrity": "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==",
+      "license": "MIT",
+      "dependencies": {
+        "copy-anything": "^4"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/supports-preserve-symlinks-flag": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "dexie": "^4.3.0",
+    "pinia": "^3.0.4",
     "vue": "^3.4.0",
     "vue-router": "^4.3.0"
   },

--- a/src/__tests__/settings.spec.ts
+++ b/src/__tests__/settings.spec.ts
@@ -1,0 +1,70 @@
+import 'fake-indexeddb/auto'
+import { describe, it, expect, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+describe('useSettingsStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('fresh store: hasApiKey is false', async () => {
+    const { useSettingsStore } = await import('@/stores/settings')
+    const store = useSettingsStore()
+    expect(store.hasApiKey).toBe(false)
+  })
+
+  it('fresh store: defaultQuestionCount is 10', async () => {
+    const { useSettingsStore } = await import('@/stores/settings')
+    const store = useSettingsStore()
+    expect(store.defaultQuestionCount).toBe(10)
+  })
+
+  it('fresh store: defaultMode is mixed', async () => {
+    const { useSettingsStore } = await import('@/stores/settings')
+    const store = useSettingsStore()
+    expect(store.defaultMode).toBe('mixed')
+  })
+
+  it('saveApiKey persists and updates reactive apiKey', async () => {
+    const { useSettingsStore } = await import('@/stores/settings')
+    const store = useSettingsStore()
+    await store.saveApiKey('sk-ant-test-123')
+    expect(store.apiKey).toBe('sk-ant-test-123')
+  })
+
+  it('hasApiKey becomes true after saving a non-empty key', async () => {
+    const { useSettingsStore } = await import('@/stores/settings')
+    const store = useSettingsStore()
+    await store.saveApiKey('sk-ant-test-123')
+    expect(store.hasApiKey).toBe(true)
+  })
+
+  it('saveDefaults persists count and mode reactively', async () => {
+    const { useSettingsStore } = await import('@/stores/settings')
+    const store = useSettingsStore()
+    await store.saveDefaults(20, 'difficult')
+    expect(store.defaultQuestionCount).toBe(20)
+    expect(store.defaultMode).toBe('difficult')
+  })
+
+  it('loadFromDB restores persisted apiKey', async () => {
+    const { useSettingsStore } = await import('@/stores/settings')
+    const store = useSettingsStore()
+    await store.saveApiKey('sk-ant-restore-test')
+    // simulate fresh load
+    store.apiKey = ''
+    await store.loadFromDB()
+    expect(store.apiKey).toBe('sk-ant-restore-test')
+  })
+
+  it('loadFromDB restores persisted defaults', async () => {
+    const { useSettingsStore } = await import('@/stores/settings')
+    const store = useSettingsStore()
+    await store.saveDefaults(65, 'new')
+    store.defaultQuestionCount = 10
+    store.defaultMode = 'mixed'
+    await store.loadFromDB()
+    expect(store.defaultQuestionCount).toBe(65)
+    expect(store.defaultMode).toBe('new')
+  })
+})

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,18 @@
 import { createApp } from 'vue'
+import { createPinia } from 'pinia'
 import App from './App.vue'
 import router from './router'
+import { useSettingsStore } from '@/stores/settings'
 
-createApp(App).use(router).mount('#app')
+;(async () => {
+  const app = createApp(App)
+  const pinia = createPinia()
+
+  app.use(pinia)
+  app.use(router)
+
+  const settingsStore = useSettingsStore()
+  await settingsStore.loadFromDB()
+
+  app.mount('#app')
+})()

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -1,0 +1,37 @@
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+import { db } from '@/db/db'
+import type { SessionMode } from '@/types'
+
+export const useSettingsStore = defineStore('settings', () => {
+  const apiKey = ref('')
+  const defaultQuestionCount = ref(10)
+  const defaultMode = ref<SessionMode>('mixed')
+
+  const hasApiKey = computed(() => apiKey.value.length > 0)
+
+  async function loadFromDB() {
+    const rows = await db.settings.toArray()
+    for (const row of rows) {
+      if (row.key === 'apiKey') apiKey.value = row.value
+      if (row.key === 'defaultQuestionCount') defaultQuestionCount.value = Number(row.value)
+      if (row.key === 'defaultMode') defaultMode.value = row.value as SessionMode
+    }
+  }
+
+  async function saveApiKey(key: string) {
+    apiKey.value = key
+    await db.settings.put({ key: 'apiKey', value: key })
+  }
+
+  async function saveDefaults(count: number, mode: SessionMode) {
+    defaultQuestionCount.value = count
+    defaultMode.value = mode
+    await db.settings.bulkPut([
+      { key: 'defaultQuestionCount', value: String(count) },
+      { key: 'defaultMode', value: mode },
+    ])
+  }
+
+  return { apiKey, defaultQuestionCount, defaultMode, hasApiKey, loadFromDB, saveApiKey, saveDefaults }
+})


### PR DESCRIPTION
## 🚀 Feature
- Adds Pinia settings store backed by IndexedDB for persistent API key and session defaults.

### 📄 Summary
- Installs `pinia` and wires it into `main.ts` before app mount.
- `useSettingsStore` uses Vue 3 composition (setup) syntax with `ref`/`computed`.
- State is loaded from IndexedDB on init via `loadFromDB()` and written through on `saveApiKey`/`saveDefaults`.

Closes #4

### 🌟 What's New
- `src/stores/settings.ts` — Pinia store exposing `apiKey`, `defaultQuestionCount`, `defaultMode`, `hasApiKey`, `loadFromDB`, `saveApiKey`, `saveDefaults`
- `src/main.ts` — Pinia registered, `loadFromDB()` awaited before `app.mount()`
- `src/__tests__/settings.spec.ts` — 8 tests covering init defaults, save/load round-trips, and `hasApiKey` computed

### 🧪 How to Test
- `npm run test` — all 22 tests pass
- `npm run build` — clean build, no TS errors

### 🖼️ UI Changes (if any)
None — data layer only.

### 📌 Checklist
- [x] Feature works as expected
- [x] Unit/integration tests added
- [x] Updated relevant documentation
- [ ] Verified in staging (if applicable)