### PR TITLE
feat(settings): settings UI (SettingsView)

### DIFF
--- a/src/__tests__/SettingsView.spec.ts
+++ b/src/__tests__/SettingsView.spec.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createRouter, createWebHashHistory } from 'vue-router'
+import { createPinia, setActivePinia } from 'pinia'
+import type { SessionMode } from '@/types'
+import SettingsView from '@/views/SettingsView.vue'
+import HomeView from '@/views/HomeView.vue'
+
+const mockSaveApiKey = vi.fn().mockResolvedValue(undefined)
+const mockSaveDefaults = vi.fn().mockResolvedValue(undefined)
+const mockLoadFromDB = vi.fn().mockResolvedValue(undefined)
+
+const mockStoreState = {
+  apiKey: '',
+  defaultQuestionCount: 10,
+  defaultMode: 'mixed' as SessionMode,
+  hasApiKey: false,
+  saveApiKey: mockSaveApiKey,
+  saveDefaults: mockSaveDefaults,
+  loadFromDB: mockLoadFromDB,
+}
+
+vi.mock('@/stores/settings', () => ({
+  useSettingsStore: vi.fn(() => mockStoreState),
+}))
+
+function makeRouter() {
+  return createRouter({
+    history: createWebHashHistory(),
+    routes: [
+      { path: '/', component: HomeView },
+      { path: '/settings', component: SettingsView },
+    ],
+  })
+}
+
+describe('SettingsView', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+    mockStoreState.apiKey = ''
+    mockStoreState.defaultQuestionCount = 10
+    mockStoreState.defaultMode = 'mixed'
+    mockStoreState.hasApiKey = false
+    mockSaveApiKey.mockResolvedValue(undefined)
+    mockSaveDefaults.mockResolvedValue(undefined)
+    mockLoadFromDB.mockResolvedValue(undefined)
+  })
+
+  it('API key field is type="password"', () => {
+    const router = makeRouter()
+    const wrapper = mount(SettingsView, { global: { plugins: [router, createPinia()] } })
+    const input = wrapper.find('input[data-testid="api-key-input"]')
+    expect(input.exists()).toBe(true)
+    expect(input.attributes('type')).toBe('password')
+  })
+
+  it('API key field pre-fills from store on mount', async () => {
+    mockStoreState.apiKey = 'sk-ant-prefill'
+    const router = makeRouter()
+    const wrapper = mount(SettingsView, { global: { plugins: [router, createPinia()] } })
+    await flushPromises()
+    const input = wrapper.find('input[data-testid="api-key-input"]')
+    expect((input.element as HTMLInputElement).value).toBe('sk-ant-prefill')
+  })
+
+  it('clicking save calls saveApiKey and shows confirmation', async () => {
+    const router = makeRouter()
+    const wrapper = mount(SettingsView, { global: { plugins: [router, createPinia()] } })
+    await flushPromises()
+    await wrapper.find('input[data-testid="api-key-input"]').setValue('sk-ant-newkey')
+    await wrapper.find('button[data-testid="save-api-key-btn"]').trigger('click')
+    await flushPromises()
+
+    expect(mockSaveApiKey).toHaveBeenCalledWith('sk-ant-newkey')
+    expect(wrapper.find('[data-testid="api-key-saved-msg"]').exists()).toBe(true)
+  })
+
+  it('saving empty input clears the key', async () => {
+    mockStoreState.apiKey = 'sk-ant-existing'
+    const router = makeRouter()
+    const wrapper = mount(SettingsView, { global: { plugins: [router, createPinia()] } })
+    await flushPromises()
+    await wrapper.find('input[data-testid="api-key-input"]').setValue('')
+    await wrapper.find('button[data-testid="save-api-key-btn"]').trigger('click')
+    await flushPromises()
+
+    expect(mockSaveApiKey).toHaveBeenCalledWith('')
+  })
+
+  it('question count field pre-fills from store defaults', async () => {
+    mockStoreState.defaultQuestionCount = 25
+    const router = makeRouter()
+    const wrapper = mount(SettingsView, { global: { plugins: [router, createPinia()] } })
+    await flushPromises()
+    const input = wrapper.find('input[data-testid="question-count-input"]')
+    expect((input.element as HTMLInputElement).value).toBe('25')
+  })
+
+  it('mode field pre-fills from store defaults', async () => {
+    mockStoreState.defaultMode = 'difficult'
+    const router = makeRouter()
+    const wrapper = mount(SettingsView, { global: { plugins: [router, createPinia()] } })
+    await flushPromises()
+    const select = wrapper.find('select[data-testid="mode-select"]')
+    expect((select.element as HTMLSelectElement).value).toBe('difficult')
+  })
+
+  it('save defaults calls saveDefaults and shows confirmation', async () => {
+    const router = makeRouter()
+    const wrapper = mount(SettingsView, { global: { plugins: [router, createPinia()] } })
+    await flushPromises()
+    await wrapper.find('input[data-testid="question-count-input"]').setValue('30')
+    await wrapper.find('select[data-testid="mode-select"]').setValue('new')
+    await wrapper.find('button[data-testid="save-defaults-btn"]').trigger('click')
+    await flushPromises()
+
+    expect(mockSaveDefaults).toHaveBeenCalledWith(30, 'new')
+    expect(wrapper.find('[data-testid="defaults-saved-msg"]').exists()).toBe(true)
+  })
+})
+
+describe('HomeView gear icon', () => {
+  it('has a link to /settings', () => {
+    const router = makeRouter()
+    const wrapper = mount(HomeView, { global: { plugins: [router, createPinia()] } })
+    const link = wrapper.find('a[href="#/settings"]')
+    expect(link.exists()).toBe(true)
+  })
+})

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -1,8 +1,14 @@
 <template>
   <main class="home-view">
-    <h1>Home</h1>
+    <header class="home-view__header">
+      <h1>Home</h1>
+      <RouterLink to="/settings" class="home-view__settings-link" aria-label="Settings">
+        ⚙
+      </RouterLink>
+    </header>
   </main>
 </template>
 
 <script setup lang="ts">
+import { RouterLink } from 'vue-router'
 </script>

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -1,8 +1,149 @@
 <template>
   <main class="settings-view">
-    <h1>Settings</h1>
+    <header class="settings-view__header">
+      <h1>Settings</h1>
+    </header>
+
+    <section class="settings-view__section">
+      <h2 class="settings-view__section-title">API Key</h2>
+      <div class="settings-view__field">
+        <label for="api-key-input">Anthropic API Key</label>
+        <input
+          id="api-key-input"
+          v-model="apiKeyInput"
+          type="password"
+          data-testid="api-key-input"
+          placeholder="sk-ant-..."
+          class="settings-view__input"
+        />
+      </div>
+      <button
+        data-testid="save-api-key-btn"
+        class="settings-view__btn"
+        @click="handleSaveApiKey"
+      >
+        Save API Key
+      </button>
+      <p v-if="apiKeySaved" data-testid="api-key-saved-msg" class="settings-view__saved-msg">
+        API key saved.
+      </p>
+    </section>
+
+    <section class="settings-view__section">
+      <h2 class="settings-view__section-title">Session Defaults</h2>
+      <div class="settings-view__field">
+        <label for="question-count-input">Default Question Count</label>
+        <input
+          id="question-count-input"
+          v-model.number="questionCountInput"
+          type="number"
+          min="5"
+          max="65"
+          data-testid="question-count-input"
+          class="settings-view__input"
+        />
+      </div>
+      <div class="settings-view__field">
+        <label for="mode-select">Default Mode</label>
+        <select
+          id="mode-select"
+          v-model="modeInput"
+          data-testid="mode-select"
+          class="settings-view__select"
+        >
+          <option value="mixed">Mixed</option>
+          <option value="review">Review</option>
+          <option value="difficult">Difficult</option>
+          <option value="new">New</option>
+        </select>
+      </div>
+      <button
+        data-testid="save-defaults-btn"
+        class="settings-view__btn"
+        @click="handleSaveDefaults"
+      >
+        Save Defaults
+      </button>
+      <p v-if="defaultsSaved" data-testid="defaults-saved-msg" class="settings-view__saved-msg">
+        Defaults saved.
+      </p>
+    </section>
   </main>
 </template>
 
 <script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { useSettingsStore } from '@/stores/settings'
+import type { SessionMode } from '@/types'
+
+const store = useSettingsStore()
+
+const apiKeyInput = ref('')
+const apiKeySaved = ref(false)
+const questionCountInput = ref(store.defaultQuestionCount)
+const modeInput = ref<SessionMode>(store.defaultMode)
+const defaultsSaved = ref(false)
+
+onMounted(async () => {
+  await store.loadFromDB()
+  apiKeyInput.value = store.apiKey
+  questionCountInput.value = store.defaultQuestionCount
+  modeInput.value = store.defaultMode
+})
+
+async function handleSaveApiKey() {
+  await store.saveApiKey(apiKeyInput.value)
+  apiKeySaved.value = true
+}
+
+async function handleSaveDefaults() {
+  await store.saveDefaults(questionCountInput.value, modeInput.value)
+  defaultsSaved.value = true
+}
 </script>
+
+<style scoped>
+.settings-view {
+  padding: 1rem;
+
+  &__header {
+    margin-bottom: 1.5rem;
+  }
+
+  &__section {
+    margin-bottom: 2rem;
+
+    &-title {
+      margin-bottom: 1rem;
+      font-size: 1.1rem;
+    }
+  }
+
+  &__field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    margin-bottom: 0.75rem;
+  }
+
+  &__input,
+  &__select {
+    padding: 0.5rem;
+    font-size: 1rem;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+  }
+
+  &__btn {
+    padding: 0.5rem 1rem;
+    font-size: 1rem;
+    cursor: pointer;
+  }
+
+  &__saved-msg {
+    margin-top: 0.5rem;
+    color: green;
+    font-size: 0.9rem;
+  }
+}
+</style>


### PR DESCRIPTION
## 🚀 Feature
- Implement SettingsView with API key management and session defaults UI.

### 📄 Summary
- Adds `src/views/SettingsView.vue` at `/#/settings` route.
- Masked API key input pre-populated from store, save button with confirmation.
- Default session preference fields (question count, mode) persisted via settingsStore.
- Gear icon on HomeView navigates to settings page.

Closes #6

### 🌟 What's New
- `SettingsView.vue` — settings page with API key and session defaults
- Route `/#/settings` added to router
- Gear icon navigation added to `HomeView.vue`

### 🧪 How to Test
- Navigate to `/#/settings`
- Enter an API key → save → reload → verify key pre-fills (masked)
- Save empty key → verify key is cleared
- Set question count and mode → reload → verify values persist
- Click gear icon on HomeView → verify navigation to settings

### 🖼️ UI Changes (if any)
- New SettingsView page at `/#/settings`
- Gear icon added to HomeView

### 📌 Checklist
- [x] Feature works as expected
- [x] Unit/integration tests added
- [x] Verified build passes