### PR TITLE
feat(topics): topic heatmap view

### DIFF
--- a/src/components/HeatmapGrid.vue
+++ b/src/components/HeatmapGrid.vue
@@ -1,0 +1,21 @@
+<template>
+  <section class="heatmap-grid">
+    <TopicTile v-for="topic in topics" :key="topic.topicId" :topic="topic" />
+  </section>
+</template>
+
+<script setup lang="ts">
+import TopicTile from '@/components/TopicTile.vue'
+import type { TopicWithScore } from '@/stores/topics'
+
+defineProps<{ topics: TopicWithScore[] }>()
+</script>
+
+<style scoped>
+.heatmap-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  gap: 0.75rem;
+  padding: 1rem;
+}
+</style>

--- a/src/components/TopicTile.vue
+++ b/src/components/TopicTile.vue
@@ -1,0 +1,54 @@
+<template>
+  <RouterLink :to="`/topics/${topic.topicId}`" class="topic-tile" :data-color="topic.color">
+    <span class="topic-tile__name">{{ topic.name }}</span>
+    <span class="topic-tile__score">{{ Math.round(topic.effectiveScore) }}%</span>
+  </RouterLink>
+</template>
+
+<script setup lang="ts">
+import type { TopicWithScore } from '@/stores/topics'
+
+defineProps<{ topic: TopicWithScore }>()
+</script>
+
+<style scoped>
+.topic-tile {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem;
+  border-radius: 8px;
+  text-decoration: none;
+  color: #fff;
+  font-weight: 600;
+  min-height: 72px;
+  background-color: #9e9e9e;
+
+  &[data-color='green'] {
+    background-color: #2e7d32;
+  }
+
+  &[data-color='yellow'] {
+    background-color: #f9a825;
+  }
+
+  &[data-color='red'] {
+    background-color: #c62828;
+  }
+
+  &[data-color='gray'] {
+    background-color: #9e9e9e;
+  }
+
+  .topic-tile__name {
+    font-size: 0.875rem;
+    text-align: center;
+  }
+
+  .topic-tile__score {
+    font-size: 1.25rem;
+    margin-top: 0.25rem;
+  }
+}
+</style>

--- a/src/components/__tests__/HeatmapGrid.spec.ts
+++ b/src/components/__tests__/HeatmapGrid.spec.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createRouter, createWebHashHistory } from 'vue-router'
+import HeatmapGrid from '@/components/HeatmapGrid.vue'
+import { TOPIC_DEFINITIONS } from '@/data/topics'
+import type { TopicWithScore } from '@/stores/topics'
+
+const router = createRouter({
+  history: createWebHashHistory(),
+  routes: [
+    { path: '/', component: { template: '<div/>' } },
+    { path: '/topics', component: { template: '<div/>' } },
+    { path: '/topics/:id', component: { template: '<div/>' } },
+  ],
+})
+
+const mockTopics: TopicWithScore[] = TOPIC_DEFINITIONS.map((t) => ({
+  ...t,
+  effectiveScore: 0,
+  color: 'gray' as const,
+}))
+
+describe('HeatmapGrid', () => {
+  it('renders 17 TopicTile components', async () => {
+    const wrapper = mount(HeatmapGrid, {
+      props: { topics: mockTopics },
+      global: { plugins: [router] },
+    })
+    expect(wrapper.findAll('.topic-tile')).toHaveLength(17)
+  })
+})

--- a/src/components/__tests__/TopicTile.spec.ts
+++ b/src/components/__tests__/TopicTile.spec.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createRouter, createWebHashHistory } from 'vue-router'
+import TopicTile from '@/components/TopicTile.vue'
+
+const router = createRouter({
+  history: createWebHashHistory(),
+  routes: [
+    { path: '/', component: { template: '<div/>' } },
+    { path: '/topics', component: { template: '<div/>' } },
+    { path: '/topics/:id', component: { template: '<div/>' } },
+  ],
+})
+
+const mockTopic = {
+  topicId: 'ec2',
+  name: 'EC2',
+  rawScore: 80,
+  lastReviewedAt: Date.now(),
+  totalSessions: 2,
+  effectiveScore: 75,
+  color: 'green' as const,
+}
+
+describe('TopicTile', () => {
+  it('renders topic name and score %', async () => {
+    const wrapper = mount(TopicTile, {
+      props: { topic: mockTopic },
+      global: { plugins: [router] },
+    })
+    expect(wrapper.text()).toContain('EC2')
+    expect(wrapper.text()).toContain('75')
+  })
+
+  it('background color matches scoreToColor output', async () => {
+    const wrapper = mount(TopicTile, {
+      props: { topic: mockTopic },
+      global: { plugins: [router] },
+    })
+    const tile = wrapper.find('.topic-tile')
+    expect(tile.attributes('data-color')).toBe('green')
+  })
+
+  it('tapping navigates to /#/topics/:id', async () => {
+    await router.isReady()
+    const wrapper = mount(TopicTile, {
+      props: { topic: mockTopic },
+      global: { plugins: [router] },
+    })
+    const link = wrapper.find('a')
+    expect(link.attributes('href')).toContain('/topics/ec2')
+  })
+})

--- a/src/composables/useNetwork.ts
+++ b/src/composables/useNetwork.ts
@@ -1,0 +1,18 @@
+import { ref, onUnmounted } from 'vue'
+
+export function useNetwork() {
+  const isOnline = ref(navigator.onLine)
+
+  function handleOnline() { isOnline.value = true }
+  function handleOffline() { isOnline.value = false }
+
+  window.addEventListener('online', handleOnline)
+  window.addEventListener('offline', handleOffline)
+
+  onUnmounted(() => {
+    window.removeEventListener('online', handleOnline)
+    window.removeEventListener('offline', handleOffline)
+  })
+
+  return { isOnline }
+}

--- a/src/stores/__tests__/topics.spec.ts
+++ b/src/stores/__tests__/topics.spec.ts
@@ -1,0 +1,52 @@
+import 'fake-indexeddb/auto'
+import { describe, it, expect, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { db } from '@/db/db'
+import { TOPIC_DEFINITIONS } from '@/data/topics'
+
+describe('useTopicsStore', () => {
+  beforeEach(async () => {
+    setActivePinia(createPinia())
+    await db.topics.clear()
+    await db.topics.bulkAdd(TOPIC_DEFINITIONS.map((t) => ({ ...t })))
+  })
+
+  it('topicsWithEffectiveScore loads 17 topics from db.topics', async () => {
+    const { useTopicsStore } = await import('@/stores/topics')
+    const store = useTopicsStore()
+    await store.refreshTopics()
+    expect(store.topicsWithEffectiveScore).toHaveLength(17)
+  })
+
+  it('each topic has effectiveScore applying SR decay at read time', async () => {
+    const { useTopicsStore } = await import('@/stores/topics')
+    const store = useTopicsStore()
+    await db.topics.where('topicId').equals('ec2').modify({ rawScore: 80, lastReviewedAt: Date.now() })
+    await store.refreshTopics()
+    const ec2 = store.topicsWithEffectiveScore.find((t) => t.topicId === 'ec2')
+    expect(ec2).toBeDefined()
+    expect(ec2!.effectiveScore).toBeGreaterThan(0)
+    expect(ec2!.effectiveScore).toBeLessThanOrEqual(80)
+  })
+
+  it('topics show score 0 and gray on first launch (never reviewed)', async () => {
+    const { useTopicsStore } = await import('@/stores/topics')
+    const store = useTopicsStore()
+    await store.refreshTopics()
+    for (const t of store.topicsWithEffectiveScore) {
+      expect(t.effectiveScore).toBe(0)
+      expect(t.color).toBe('gray')
+    }
+  })
+
+  it('refreshTopics re-queries DB and updates state reactively', async () => {
+    const { useTopicsStore } = await import('@/stores/topics')
+    const store = useTopicsStore()
+    await store.refreshTopics()
+    expect(store.topicsWithEffectiveScore).toHaveLength(17)
+    await db.topics.where('topicId').equals('s3').modify({ rawScore: 75, lastReviewedAt: Date.now() })
+    await store.refreshTopics()
+    const s3 = store.topicsWithEffectiveScore.find((t) => t.topicId === 's3')
+    expect(s3!.effectiveScore).toBeGreaterThan(0)
+  })
+})

--- a/src/stores/topics.ts
+++ b/src/stores/topics.ts
@@ -1,0 +1,31 @@
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+import { db } from '@/db/db'
+import type { Topic } from '@/types'
+import { effectiveScore, scoreToColor } from '@/composables/useSpacedRepetition'
+
+export interface TopicWithScore extends Topic {
+  effectiveScore: number
+  color: 'green' | 'yellow' | 'red' | 'gray'
+}
+
+export const useTopicsStore = defineStore('topics', () => {
+  const topics = ref<Topic[]>([])
+
+  const topicsWithEffectiveScore = computed<TopicWithScore[]>(() =>
+    topics.value.map((t) => {
+      const score = effectiveScore(t.rawScore, t.lastReviewedAt)
+      return {
+        ...t,
+        effectiveScore: score,
+        color: scoreToColor(score, t.lastReviewedAt),
+      }
+    }),
+  )
+
+  async function refreshTopics() {
+    topics.value = await db.topics.toArray()
+  }
+
+  return { topicsWithEffectiveScore, refreshTopics }
+})

--- a/src/views/TopicsView.vue
+++ b/src/views/TopicsView.vue
@@ -1,8 +1,29 @@
 <template>
   <main class="topics-view">
-    <h1>Topics</h1>
+    <h1 class="topics-view__title">Topics</h1>
+    <HeatmapGrid :topics="store.topicsWithEffectiveScore" />
   </main>
 </template>
 
 <script setup lang="ts">
+import { onMounted } from 'vue'
+import HeatmapGrid from '@/components/HeatmapGrid.vue'
+import { useTopicsStore } from '@/stores/topics'
+
+const store = useTopicsStore()
+
+onMounted(() => {
+  store.refreshTopics()
+})
 </script>
+
+<style scoped>
+.topics-view {
+  padding-bottom: 4rem;
+
+  .topics-view__title {
+    padding: 1rem;
+    margin: 0;
+  }
+}
+</style>

--- a/src/views/__tests__/TopicsView.spec.ts
+++ b/src/views/__tests__/TopicsView.spec.ts
@@ -1,0 +1,44 @@
+import 'fake-indexeddb/auto'
+import { describe, it, expect, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createRouter, createWebHashHistory } from 'vue-router'
+import { createPinia, setActivePinia } from 'pinia'
+import { db } from '@/db/db'
+import { TOPIC_DEFINITIONS } from '@/data/topics'
+import TopicsView from '@/views/TopicsView.vue'
+
+const router = createRouter({
+  history: createWebHashHistory(),
+  routes: [
+    { path: '/topics', component: TopicsView },
+    { path: '/topics/:id', component: { template: '<div/>' } },
+  ],
+})
+
+describe('TopicsView', () => {
+  beforeEach(async () => {
+    setActivePinia(createPinia())
+    await db.topics.clear()
+    await db.topics.bulkAdd(TOPIC_DEFINITIONS.map((t) => ({ ...t })))
+  })
+
+  it('route /#/topics renders HeatmapGrid', async () => {
+    await router.push('/topics')
+    await router.isReady()
+    const wrapper = mount(TopicsView, {
+      global: { plugins: [router, createPinia()] },
+    })
+    await flushPromises()
+    expect(wrapper.find('.heatmap-grid').exists()).toBe(true)
+  })
+
+  it('all 17 tiles visible', async () => {
+    await router.push('/topics')
+    await router.isReady()
+    const wrapper = mount(TopicsView, {
+      global: { plugins: [router, createPinia()] },
+    })
+    await flushPromises()
+    expect(wrapper.findAll('.topic-tile')).toHaveLength(17)
+  })
+})


### PR DESCRIPTION
## 🚀 Feature
- Implement topic heatmap view with Pinia store, TopicTile, HeatmapGrid, and TopicsView.

### 📄 Summary
- `src/stores/topics.ts` — Pinia store loading 17 topics from db.topics, exposes `topicsWithEffectiveScore` getter (SR decay at read time), `refreshTopics()` action.
- `TopicTile.vue` — shows topic name, effective score %, colored by scoreToColor.
- `HeatmapGrid.vue` — grid of 17 tiles.
- `TopicsView.vue` — renders at `/#/topics`.

Closes #7

### 🌟 What's New
- `src/stores/topics.ts`
- `src/components/TopicTile.vue`
- `src/components/HeatmapGrid.vue`
- `src/views/TopicsView.vue`
- Routes `/#/topics` and `/#/topics/:id`

### 🧪 How to Test
- Navigate to `/#/topics` → 17 tiles visible
- All tiles gray on first launch
- After study session, `refreshTopics()` updates tile colors
- Tap tile → navigates to `/#/topics/:id`

### 🖼️ UI Changes (if any)
- New TopicsView heatmap grid at `/#/topics`

### 📌 Checklist
- [x] Feature works as expected
- [x] Unit tests added
- [x] Build passes