### PR TITLE
feat(study): session configurator

### DIFF
--- a/src/composables/__tests__/useNetwork.spec.ts
+++ b/src/composables/__tests__/useNetwork.spec.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+describe('useNetwork', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('isOnline ref is true when navigator.onLine is true', async () => {
+    Object.defineProperty(navigator, 'onLine', { value: true, configurable: true })
+    const { useNetwork } = await import('@/composables/useNetwork')
+    const { isOnline } = useNetwork()
+    expect(isOnline.value).toBe(true)
+  })
+
+  it('isOnline updates reactively when online/offline events fire', async () => {
+    Object.defineProperty(navigator, 'onLine', { value: true, configurable: true })
+    const { useNetwork } = await import('@/composables/useNetwork')
+    const { isOnline } = useNetwork()
+    expect(isOnline.value).toBe(true)
+
+    window.dispatchEvent(new Event('offline'))
+    expect(isOnline.value).toBe(false)
+
+    window.dispatchEvent(new Event('online'))
+    expect(isOnline.value).toBe(true)
+  })
+})

--- a/src/composables/useNetwork.ts
+++ b/src/composables/useNetwork.ts
@@ -1,0 +1,18 @@
+import { ref, onUnmounted } from 'vue'
+
+export function useNetwork() {
+  const isOnline = ref(navigator.onLine)
+
+  function handleOnline() { isOnline.value = true }
+  function handleOffline() { isOnline.value = false }
+
+  window.addEventListener('online', handleOnline)
+  window.addEventListener('offline', handleOffline)
+
+  onUnmounted(() => {
+    window.removeEventListener('online', handleOnline)
+    window.removeEventListener('offline', handleOffline)
+  })
+
+  return { isOnline }
+}

--- a/src/stores/__tests__/session.spec.ts
+++ b/src/stores/__tests__/session.spec.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import type { SessionConfig } from '@/types/index'
+
+describe('useSessionStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('initial state is idle', async () => {
+    const { useSessionStore } = await import('@/stores/session')
+    const store = useSessionStore()
+    expect(store.status).toBe('idle')
+  })
+
+  it('configure(config) updates store state', async () => {
+    const { useSessionStore } = await import('@/stores/session')
+    const store = useSessionStore()
+    const config: SessionConfig = {
+      topicIds: ['ec2', 's3'],
+      mode: 'mixed',
+      questionCount: 10,
+      feedbackMode: 'study',
+      timerEnabled: false,
+      timerSeconds: 90,
+    }
+    store.configure(config)
+    expect(store.config).toEqual(config)
+    expect(store.status).toBe('configured')
+  })
+
+  it('SessionConfig includes topics[], mode, questionCount, feedbackMode, timerEnabled, timerSeconds', async () => {
+    const { useSessionStore } = await import('@/stores/session')
+    const store = useSessionStore()
+    const config: SessionConfig = {
+      topicIds: ['vpc', 'iam', 'rds'],
+      mode: 'difficult',
+      questionCount: 20,
+      feedbackMode: 'exam',
+      timerEnabled: true,
+      timerSeconds: 120,
+    }
+    store.configure(config)
+    expect(store.config?.topicIds).toEqual(['vpc', 'iam', 'rds'])
+    expect(store.config?.mode).toBe('difficult')
+    expect(store.config?.questionCount).toBe(20)
+    expect(store.config?.feedbackMode).toBe('exam')
+    expect(store.config?.timerEnabled).toBe(true)
+    expect(store.config?.timerSeconds).toBe(120)
+  })
+})

--- a/src/stores/session.ts
+++ b/src/stores/session.ts
@@ -1,0 +1,22 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import type { SessionConfig } from '@/types/index'
+
+export type SessionStatus = 'idle' | 'configured' | 'loading' | 'active' | 'review'
+
+export const useSessionStore = defineStore('session', () => {
+  const status = ref<SessionStatus>('idle')
+  const config = ref<SessionConfig | null>(null)
+
+  function configure(newConfig: SessionConfig) {
+    config.value = newConfig
+    status.value = 'configured'
+  }
+
+  function reset() {
+    config.value = null
+    status.value = 'idle'
+  }
+
+  return { status, config, configure, reset }
+})

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,7 +1,16 @@
 export type QuestionSource = 'seed' | 'generated'
 export type SessionMode = 'review' | 'difficult' | 'new' | 'mixed'
 export type FeedbackMode = 'study' | 'exam'
-export type SettingKey = 'apiKey' | 'defaultQuestionCount' | 'defaultMode'
+export type SettingKey =
+  | 'apiKey'
+  | 'defaultQuestionCount'
+  | 'defaultMode'
+  | 'session_topicIds'
+  | 'session_mode'
+  | 'session_questionCount'
+  | 'session_feedbackMode'
+  | 'session_timerEnabled'
+  | 'session_timerSeconds'
 
 export interface Question {
   id?: number

--- a/src/views/StudyView.vue
+++ b/src/views/StudyView.vue
@@ -1,8 +1,240 @@
 <template>
   <main class="study-view">
-    <h1>Study</h1>
+    <h1 class="study-view__title">Configure Session</h1>
+
+    <form class="study-view__form" @submit.prevent="startSession">
+      <section class="study-view__section">
+        <h2 class="study-view__section-heading">Topics</h2>
+        <label class="study-view__topic-item">
+          <input
+            type="checkbox"
+            data-testid="topic-all"
+            :checked="allSelected"
+            @change="toggleAll"
+          />
+          All
+        </label>
+        <label
+          v-for="topic in TOPIC_DEFINITIONS"
+          :key="topic.topicId"
+          class="study-view__topic-item"
+        >
+          <input
+            type="checkbox"
+            :data-testid="`topic-${topic.topicId}`"
+            :value="topic.topicId"
+            v-model="selectedTopics"
+          />
+          {{ topic.name }}
+        </label>
+      </section>
+
+      <section class="study-view__section">
+        <h2 class="study-view__section-heading">Mode</h2>
+        <div class="study-view__mode-group">
+          <label
+            v-for="m in modes"
+            :key="m.value"
+            class="study-view__mode-option"
+          >
+            <input
+              type="radio"
+              :data-testid="`mode-${m.value}`"
+              :value="m.value"
+              v-model="selectedMode"
+            />
+            {{ m.label }}
+          </label>
+        </div>
+      </section>
+
+      <section class="study-view__section">
+        <h2 class="study-view__section-heading">Question Count</h2>
+        <input
+          type="number"
+          data-testid="question-count"
+          min="5"
+          max="65"
+          v-model.number="questionCount"
+        />
+      </section>
+
+      <section class="study-view__section">
+        <h2 class="study-view__section-heading">Feedback Mode</h2>
+        <div class="study-view__feedback-group">
+          <label class="study-view__feedback-option">
+            <input
+              type="radio"
+              data-testid="feedback-study"
+              value="study"
+              v-model="feedbackMode"
+            />
+            Study
+          </label>
+          <label class="study-view__feedback-option">
+            <input
+              type="radio"
+              data-testid="feedback-exam"
+              value="exam"
+              v-model="feedbackMode"
+            />
+            Exam
+          </label>
+        </div>
+      </section>
+
+      <section class="study-view__section">
+        <h2 class="study-view__section-heading">Timer</h2>
+        <label class="study-view__timer-toggle">
+          <input
+            type="checkbox"
+            data-testid="timer-toggle"
+            v-model="timerEnabled"
+          />
+          Enable timer
+        </label>
+        <input
+          v-if="timerEnabled"
+          type="number"
+          data-testid="timer-seconds"
+          min="30"
+          max="7200"
+          v-model.number="timerSeconds"
+        />
+      </section>
+
+      <button
+        type="submit"
+        data-testid="start-session"
+        :disabled="selectedTopics.length === 0"
+        class="study-view__start-btn"
+      >
+        Start Session
+      </button>
+    </form>
   </main>
 </template>
 
 <script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { TOPIC_DEFINITIONS } from '@/data/topics'
+import { useSessionStore } from '@/stores/session'
+import { db } from '@/db/db'
+import type { SessionMode, FeedbackMode } from '@/types/index'
+
+const router = useRouter()
+const sessionStore = useSessionStore()
+
+const selectedTopics = ref<string[]>([])
+const selectedMode = ref<SessionMode>('mixed')
+const questionCount = ref(10)
+const feedbackMode = ref<FeedbackMode>('study')
+const timerEnabled = ref(false)
+const timerSeconds = ref(90)
+
+const allTopicIds = TOPIC_DEFINITIONS.map((t) => t.topicId)
+
+const allSelected = computed(() => selectedTopics.value.length === allTopicIds.length)
+
+const modes = [
+  { value: 'review' as SessionMode, label: 'Review' },
+  { value: 'difficult' as SessionMode, label: 'Difficult' },
+  { value: 'new' as SessionMode, label: 'New' },
+  { value: 'mixed' as SessionMode, label: 'Mixed' },
+]
+
+function toggleAll(e: Event) {
+  const checked = (e.target as HTMLInputElement).checked
+  selectedTopics.value = checked ? [...allTopicIds] : []
+}
+
+onMounted(async () => {
+  const rows = await db.settings.where('key').startsWith('session_').toArray()
+  for (const row of rows) {
+    if (row.key === 'session_topicIds') selectedTopics.value = JSON.parse(row.value)
+    if (row.key === 'session_mode') selectedMode.value = row.value as SessionMode
+    if (row.key === 'session_questionCount') questionCount.value = Number(row.value)
+    if (row.key === 'session_feedbackMode') feedbackMode.value = row.value as FeedbackMode
+    if (row.key === 'session_timerEnabled') timerEnabled.value = row.value === 'true'
+    if (row.key === 'session_timerSeconds') timerSeconds.value = Number(row.value)
+  }
+})
+
+async function startSession() {
+  const config = {
+    topicIds: selectedTopics.value,
+    mode: selectedMode.value,
+    questionCount: questionCount.value,
+    feedbackMode: feedbackMode.value,
+    timerEnabled: timerEnabled.value,
+    timerSeconds: timerSeconds.value,
+  }
+
+  await db.settings.bulkPut([
+    { key: 'session_topicIds', value: JSON.stringify(config.topicIds) },
+    { key: 'session_mode', value: config.mode },
+    { key: 'session_questionCount', value: String(config.questionCount) },
+    { key: 'session_feedbackMode', value: config.feedbackMode },
+    { key: 'session_timerEnabled', value: String(config.timerEnabled) },
+    { key: 'session_timerSeconds', value: String(config.timerSeconds) },
+  ])
+
+  sessionStore.configure(config)
+  router.push('/study/session')
+}
 </script>
+
+<style scoped>
+.study-view {
+  padding: 1rem;
+
+  &__title {
+    margin-bottom: 1.5rem;
+  }
+
+  &__form {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+  }
+
+  &__section {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  &__section-heading {
+    font-size: 1rem;
+    font-weight: 600;
+    margin-bottom: 0.25rem;
+  }
+
+  &__topic-item,
+  &__mode-option,
+  &__feedback-option,
+  &__timer-toggle {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    cursor: pointer;
+  }
+
+  &__mode-group,
+  &__feedback-group {
+    display: flex;
+    gap: 1rem;
+  }
+
+  &__start-btn {
+    align-self: flex-start;
+    padding: 0.75rem 1.5rem;
+
+    &:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+  }
+}
+</style>

--- a/src/views/__tests__/StudyView.spec.ts
+++ b/src/views/__tests__/StudyView.spec.ts
@@ -1,0 +1,131 @@
+import 'fake-indexeddb/auto'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { setActivePinia, createPinia } from 'pinia'
+import { createRouter, createWebHashHistory } from 'vue-router'
+import { db } from '@/db/db'
+import { TOPIC_DEFINITIONS } from '@/data/topics'
+import StudyView from '@/views/StudyView.vue'
+
+vi.mock('@/composables/useNetwork', () => ({
+  useNetwork: () => ({ isOnline: { value: true } }),
+}))
+
+async function checkCheckbox(wrapper: ReturnType<typeof mount>, testId: string) {
+  const el = wrapper.find(`[data-testid="${testId}"]`)
+  ;(el.element as HTMLInputElement).checked = true
+  await el.trigger('change')
+  await flushPromises()
+}
+
+function mountStudyView() {
+  const router = createRouter({
+    history: createWebHashHistory(),
+    routes: [
+      { path: '/study', component: StudyView },
+      { path: '/study/session', component: { template: '<div>session</div>' } },
+    ],
+  })
+  return mount(StudyView, {
+    global: { plugins: [router] },
+  })
+}
+
+describe('StudyView', () => {
+  beforeEach(async () => {
+    setActivePinia(createPinia())
+    await db.topics.clear()
+    await db.topics.bulkAdd(TOPIC_DEFINITIONS.map((t) => ({ ...t })))
+    await db.settings.clear()
+  })
+
+  it('renders topic multi-select with all 17 topics + "All" shortcut', async () => {
+    const wrapper = mountStudyView()
+    await flushPromises()
+    const topicCheckboxes = wrapper.findAll('[data-testid^="topic-"]:not([data-testid="topic-all"])')
+    expect(topicCheckboxes).toHaveLength(17)
+    expect(wrapper.find('[data-testid="topic-all"]').exists()).toBe(true)
+  })
+
+  it('renders mode selector with Review/Difficult/New/Mixed options', async () => {
+    const wrapper = mountStudyView()
+    await flushPromises()
+    const modeOptions = ['review', 'difficult', 'new', 'mixed']
+    for (const mode of modeOptions) {
+      expect(wrapper.find(`[data-testid="mode-${mode}"]`).exists()).toBe(true)
+    }
+  })
+
+  it('renders question count input with range 5-65 and default 10', async () => {
+    const wrapper = mountStudyView()
+    await flushPromises()
+    const input = wrapper.find('[data-testid="question-count"]')
+    expect(input.exists()).toBe(true)
+    expect((input.element as HTMLInputElement).min).toBe('5')
+    expect((input.element as HTMLInputElement).max).toBe('65')
+    expect((input.element as HTMLInputElement).value).toBe('10')
+  })
+
+  it('renders feedback mode toggle (Study/Exam)', async () => {
+    const wrapper = mountStudyView()
+    await flushPromises()
+    expect(wrapper.find('[data-testid="feedback-study"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="feedback-exam"]').exists()).toBe(true)
+  })
+
+  it('renders timer toggle; when enabled, shows time input', async () => {
+    const wrapper = mountStudyView()
+    await flushPromises()
+    const timerToggle = wrapper.find('[data-testid="timer-toggle"]')
+    expect(timerToggle.exists()).toBe(true)
+    expect(wrapper.find('[data-testid="timer-seconds"]').exists()).toBe(false)
+
+    await checkCheckbox(wrapper, 'timer-toggle')
+    expect(wrapper.find('[data-testid="timer-seconds"]').exists()).toBe(true)
+  })
+
+  it('"Start Session" is disabled when no topic selected', async () => {
+    const wrapper = mountStudyView()
+    await flushPromises()
+    const btn = wrapper.find('[data-testid="start-session"]')
+    expect(btn.exists()).toBe(true)
+    expect((btn.element as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('"Start Session" calls sessionStore.configure() and navigates to /study/session', async () => {
+    const wrapper = mountStudyView()
+    await flushPromises()
+
+    await checkCheckbox(wrapper, 'topic-ec2')
+
+    const btn = wrapper.find('[data-testid="start-session"]')
+    expect((btn.element as HTMLButtonElement).disabled).toBe(false)
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+
+    const saved = await db.settings.toArray()
+    const topicsSetting = saved.find((s) => s.key === 'session_topicIds')
+    expect(topicsSetting).toBeDefined()
+    expect(JSON.parse(topicsSetting!.value)).toContain('ec2')
+  })
+
+  it('config saves to settingsStore and pre-fills on next visit', async () => {
+    const wrapper = mountStudyView()
+    await flushPromises()
+
+    await wrapper.find('[data-testid="question-count"]').setValue('20')
+    await flushPromises()
+
+    await checkCheckbox(wrapper, 'topic-ec2')
+
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+
+    const saved = await db.settings.toArray()
+    const sessionKeys = saved.filter((s) => s.key.startsWith('session_'))
+    expect(sessionKeys.length).toBeGreaterThan(0)
+
+    const countSetting = saved.find((s) => s.key === 'session_questionCount')
+    expect(countSetting?.value).toBe('20')
+  })
+})


### PR DESCRIPTION
## 🚀 Feature
- Implement session configurator with useNetwork composable, session store, and StudyView.

### 📄 Summary
- `src/composables/useNetwork.ts` — reactive `isOnline` ref.
- `src/stores/session.ts` — Pinia store with idle state and `configure()` action.
- `src/views/StudyView.vue` — full configurator at `/#/study`: topic multi-select, mode selector, question count, feedback mode, timer toggle.
- Last-used config persists to settingsStore and pre-fills on next visit.

Closes #8

### 🌟 What's New
- `src/composables/useNetwork.ts`
- `src/stores/session.ts`
- `src/views/StudyView.vue`
- Routes `/#/study` and `/#/study/session`

### 🧪 How to Test
- Navigate to `/#/study`
- Select topics, mode, count, feedback mode
- Enable timer → time input appears
- Deselect all topics → Start Session disabled
- Start session → navigates to `/#/study/session`
- Revisit `/#/study` → config pre-fills from last session

### 🖼️ UI Changes (if any)
- New StudyView configurator at `/#/study`

### 📌 Checklist
- [x] Feature works as expected
- [x] Unit tests added
- [x] Build passes