### PR TITLE
feat(ai): online question generation (Claude API)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "exam-creator",
       "version": "0.1.0",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.80.0",
         "dexie": "^4.3.0",
         "pinia": "^3.0.4",
         "vue": "^3.4.0",
@@ -23,6 +24,26 @@
         "vite-plugin-pwa": "^0.20.0",
         "vitest": "^1.4.0",
         "vue-tsc": "^2.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.80.0.tgz",
+      "integrity": "sha512-WeXLn7zNVk3yjeshn+xZHvld6AoFUOR3Sep6pSoHho5YbSi6HwcirqgPA5ccFuW8QTVJAAU7N8uQQC6Wa9TG+g==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@apideck/better-ajv-errors": {
@@ -1591,7 +1612,6 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -5302,6 +5322,19 @@
       "dev": true,
       "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -7018,6 +7051,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
     },
     "node_modules/type-detect": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.80.0",
     "dexie": "^4.3.0",
     "pinia": "^3.0.4",
     "vue": "^3.4.0",

--- a/src/composables/__tests__/useQuestionGenerator.spec.ts
+++ b/src/composables/__tests__/useQuestionGenerator.spec.ts
@@ -1,0 +1,110 @@
+import 'fake-indexeddb/auto'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import Dexie from 'dexie'
+import type { Question, Topic, Session, Setting } from '@/types'
+
+const mockCreate = vi.fn()
+
+vi.mock('@anthropic-ai/sdk', () => ({
+  default: class MockAnthropic {
+    messages = {
+      stream: mockCreate,
+    }
+  },
+}))
+
+function freshDb() {
+  const name = `TestExamDB_${Math.random().toString(36).slice(2)}`
+  class TestDB extends Dexie {
+    questions!: Dexie.Table<Question>
+    topics!: Dexie.Table<Topic>
+    sessions!: Dexie.Table<Session>
+    settings!: Dexie.Table<Setting>
+    constructor() {
+      super(name)
+      this.version(1).stores({
+        questions: '++id, topicId, errorCount, lastSeenAt',
+        topics: '++id, &topicId',
+        sessions: '++id, startedAt, completedAt, mode',
+        settings: '&key',
+      })
+    }
+  }
+  return new TestDB()
+}
+
+const validQuestions = [
+  {
+    topicId: 'ec2',
+    text: 'What is EC2?',
+    options: ['A virtual machine service', 'A storage service', 'A database service', 'A CDN service'],
+    correctIndex: 0,
+    explanation: 'EC2 is Amazon Elastic Compute Cloud, a virtual machine service.',
+  },
+]
+
+describe('useQuestionGenerator', () => {
+  beforeEach(() => {
+    mockCreate.mockReset()
+    Object.defineProperty(navigator, 'onLine', { value: true, configurable: true, writable: true })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('valid response → questions persisted to DB and returned with IDs', async () => {
+    mockCreate.mockReturnValue({
+      finalText: async () => JSON.stringify(validQuestions),
+    })
+
+    const db = freshDb() as any
+    const { useQuestionGenerator } = await import('@/composables/useQuestionGenerator')
+    const result = await useQuestionGenerator({ topicIds: ['ec2'], count: 1, apiKey: 'test-key', db })
+
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBeDefined()
+    expect(result[0].source).toBe('generated')
+    expect(result[0].topicId).toBe('ec2')
+
+    const dbCount = await db.questions.count()
+    expect(dbCount).toBe(1)
+  })
+
+  it('malformed JSON response → returns empty array, no DB writes', async () => {
+    mockCreate.mockReturnValue({
+      finalText: async () => 'this is not valid json {{{',
+    })
+
+    const db = freshDb() as any
+    const { useQuestionGenerator } = await import('@/composables/useQuestionGenerator')
+    const result = await useQuestionGenerator({ topicIds: ['ec2'], count: 1, apiKey: 'test-key', db })
+
+    expect(result).toEqual([])
+    const dbCount = await db.questions.count()
+    expect(dbCount).toBe(0)
+  })
+
+  it('offline → returns empty array without calling SDK', async () => {
+    Object.defineProperty(navigator, 'onLine', { value: false, configurable: true, writable: true })
+
+    const db = freshDb() as any
+    const { useQuestionGenerator } = await import('@/composables/useQuestionGenerator')
+    const result = await useQuestionGenerator({ topicIds: ['ec2'], count: 1, apiKey: 'test-key', db })
+
+    expect(result).toEqual([])
+    expect(mockCreate).not.toHaveBeenCalled()
+  })
+
+  it('API error → returns empty array gracefully', async () => {
+    mockCreate.mockRejectedValue(new Error('API error: 401 Unauthorized'))
+
+    const db = freshDb() as any
+    const { useQuestionGenerator } = await import('@/composables/useQuestionGenerator')
+    const result = await useQuestionGenerator({ topicIds: ['ec2'], count: 1, apiKey: 'bad-key', db })
+
+    expect(result).toEqual([])
+    const dbCount = await db.questions.count()
+    expect(dbCount).toBe(0)
+  })
+})

--- a/src/composables/useQuestionGenerator.ts
+++ b/src/composables/useQuestionGenerator.ts
@@ -1,0 +1,95 @@
+import Anthropic from '@anthropic-ai/sdk'
+import type { GeneratedQuestion, Question } from '@/types'
+import type { ExamDB } from '@/db/db'
+
+export const QUESTION_GENERATION_PROMPT = `Generate AWS SAA-C03 exam practice questions as a JSON array.
+
+Each question must have:
+- topicId: string (AWS service/domain slug, e.g. "ec2", "s3", "vpc", "iam", "rds")
+- text: string (the question text)
+- options: string[] (exactly 4 answer options)
+- correctIndex: number (0-based index of the correct option)
+- explanation: string (why the correct answer is right)
+
+Return ONLY a valid JSON array with no markdown, no code fences, no extra text.`
+
+function isValidGeneratedQuestion(item: unknown): item is GeneratedQuestion {
+  if (!item || typeof item !== 'object') return false
+  const q = item as Record<string, unknown>
+  return (
+    typeof q.topicId === 'string' &&
+    typeof q.text === 'string' &&
+    Array.isArray(q.options) &&
+    q.options.length === 4 &&
+    q.options.every((o) => typeof o === 'string') &&
+    typeof q.correctIndex === 'number' &&
+    typeof q.explanation === 'string'
+  )
+}
+
+interface UseQuestionGeneratorOptions {
+  topicIds: string[]
+  count: number
+  apiKey: string
+  db: ExamDB
+}
+
+export async function useQuestionGenerator({
+  topicIds,
+  count,
+  apiKey,
+  db,
+}: UseQuestionGeneratorOptions): Promise<Question[]> {
+  if (!navigator.onLine) return []
+
+  try {
+    const client = new Anthropic({ apiKey, dangerouslyAllowBrowser: true })
+
+    const topicList = topicIds.join(', ')
+    const userPrompt = `Generate ${count} AWS SAA-C03 practice questions for these topics: ${topicList}. Return a JSON array of ${count} question objects.`
+
+    const stream = await client.messages.stream({
+      model: 'claude-sonnet-4-6',
+      max_tokens: 4096,
+      messages: [
+        {
+          role: 'user',
+          content: `${QUESTION_GENERATION_PROMPT}\n\n${userPrompt}`,
+        },
+      ],
+    })
+
+    const text = await stream.finalText()
+
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(text)
+    } catch {
+      return []
+    }
+
+    if (!Array.isArray(parsed)) return []
+
+    const valid = parsed.filter(isValidGeneratedQuestion)
+    if (valid.length === 0) return []
+
+    const now = Date.now()
+    const toInsert: Question[] = valid.map((q) => ({
+      topicId: q.topicId,
+      text: q.text,
+      options: q.options,
+      correctIndex: q.correctIndex,
+      explanation: q.explanation,
+      source: 'generated',
+      errorCount: 0,
+      lastSeenAt: null,
+      createdAt: now,
+    }))
+
+    const ids = await db.questions.bulkAdd(toInsert, { allKeys: true }) as number[]
+
+    return toInsert.map((q, i) => ({ ...q, id: ids[i] }))
+  } catch {
+    return []
+  }
+}

--- a/src/views/SessionView.vue
+++ b/src/views/SessionView.vue
@@ -1,8 +1,49 @@
 <template>
   <main class="session-view">
-    <h1>Session</h1>
+    <div v-if="sessionStore.status === 'loading'" class="session-view__loading">
+      <span class="session-view__spinner" aria-label="Generating questions…"></span>
+      <p class="session-view__loading-text">Generating questions…</p>
+    </div>
+    <h1 v-else>Session</h1>
   </main>
 </template>
 
 <script setup lang="ts">
+import { useSessionStore } from '@/stores/session'
+
+const sessionStore = useSessionStore()
 </script>
+
+<style scoped>
+.session-view {
+  padding: 1rem;
+
+  &__loading {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 1rem;
+    padding: 3rem 1rem;
+  }
+
+  &__spinner {
+    display: block;
+    width: 2.5rem;
+    height: 2.5rem;
+    border: 3px solid currentColor;
+    border-top-color: transparent;
+    border-radius: 50%;
+    animation: spin 0.75s linear infinite;
+  }
+
+  &__loading-text {
+    font-size: 1rem;
+    color: inherit;
+  }
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+</style>

--- a/src/views/StudyView.vue
+++ b/src/views/StudyView.vue
@@ -120,11 +120,16 @@ import { ref, computed, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { TOPIC_DEFINITIONS } from '@/data/topics'
 import { useSessionStore } from '@/stores/session'
+import { useSettingsStore } from '@/stores/settings'
+import { useNetwork } from '@/composables/useNetwork'
+import { useQuestionGenerator } from '@/composables/useQuestionGenerator'
 import { db } from '@/db/db'
 import type { SessionMode, FeedbackMode } from '@/types/index'
 
 const router = useRouter()
 const sessionStore = useSessionStore()
+const settingsStore = useSettingsStore()
+const { isOnline } = useNetwork()
 
 const selectedTopics = ref<string[]>([])
 const selectedMode = ref<SessionMode>('mixed')
@@ -181,6 +186,23 @@ async function startSession() {
   ])
 
   sessionStore.configure(config)
+
+  const shouldGenerate =
+    isOnline.value &&
+    settingsStore.hasApiKey &&
+    (config.mode === 'new' || config.mode === 'mixed')
+
+  if (shouldGenerate) {
+    sessionStore.status = 'loading'
+    await useQuestionGenerator({
+      topicIds: config.topicIds,
+      count: config.questionCount,
+      apiKey: settingsStore.apiKey,
+      db,
+    })
+    sessionStore.status = 'configured'
+  }
+
   router.push('/study/session')
 }
 </script>


### PR DESCRIPTION
## 🚀 Feature
- Implements online question generation via Claude API (claude-sonnet-4-6)

### 📄 Summary
- Adds useQuestionGenerator composable that calls Anthropic SDK with streaming
- Validates and persists generated questions to IndexedDB with source: 'generated'
- Integrates into study flow: generates questions before session when online + API key present
- Graceful fallback to existing DB questions on any error (offline, bad key, bad JSON)

### 🌟 What's New
- useQuestionGenerator composable
- QUESTION_GENERATION_PROMPT named constant
- Loading spinner during generation (sessionStore status: 'loading')
- Integration tests with mocked Anthropic SDK

### 🧪 How to Test
- Run `npm run test` to verify integration tests pass
- Set a valid Anthropic API key in settings
- Start a "New" or "Mixed" session while online — verify questions are generated
- Disconnect network, start session — verify fallback to existing questions
- Use invalid API key — verify graceful fallback

### 🖼️ UI Changes (if any)
- Loading spinner shown on SessionView while generating questions

### 📌 Checklist
- [ ] Feature works as expected
- [ ] Unit/integration tests added (if applicable)
- [ ] Updated relevant documentation
- [ ] Verified in staging (if applicable)

Closes #14