### PR TITLE
feat(sr): post-session SR score updates

### DIFF
--- a/src/composables/__tests__/useSession.spec.ts
+++ b/src/composables/__tests__/useSession.spec.ts
@@ -2,7 +2,26 @@ import { describe, it, expect, beforeEach } from 'vitest'
 import 'fake-indexeddb/auto'
 import Dexie from 'dexie'
 import { ExamDB } from '@/db/db'
-import type { Question } from '@/types'
+import type { Question, Topic, SessionConfig } from '@/types'
+import type { AnswerRecord } from '@/composables/useSession'
+
+function makeTopic(overrides: Partial<Topic> & { topicId: string }): Omit<Topic, 'id'> {
+  return {
+    name: overrides.topicId.toUpperCase(),
+    rawScore: 50,
+    lastReviewedAt: null,
+    totalSessions: 0,
+    ...overrides,
+  }
+}
+
+function makeConfig(topicIds: string[]): SessionConfig {
+  return { topicIds, mode: 'mixed', questionCount: 10, feedbackMode: 'study', timerEnabled: false, timerSeconds: 0 }
+}
+
+function makeAnswer(correct: boolean): AnswerRecord {
+  return { questionId: 1, selectedIndex: 0, timeMs: 0, correct }
+}
 
 let db: ExamDB
 
@@ -176,5 +195,66 @@ describe('buildQuestionQueue', () => {
 
     expect(queue.length).toBe(2)
     expect(queue.every((q) => ['s3', 'vpc'].includes(q.topicId))).toBe(true)
+  })
+})
+
+describe('completeSession', () => {
+  it('updates rawScore and lastReviewedAt for touched topics', async () => {
+    await db.topics.bulkAdd([makeTopic({ topicId: 'ec2', rawScore: 50 })])
+    const { completeSession } = await import('@/composables/useSession')
+    const answers = [makeAnswer(true), makeAnswer(true)]
+    await completeSession(makeConfig(['ec2']), answers, Date.now() - 1000, db)
+    const topic = await db.topics.where('topicId').equals('ec2').first()
+    expect(topic?.rawScore).toBeGreaterThan(50)
+    expect(topic?.lastReviewedAt).not.toBeNull()
+  })
+
+  it('100% correct session raises rawScore', async () => {
+    await db.topics.bulkAdd([makeTopic({ topicId: 'ec2', rawScore: 50 })])
+    const { completeSession } = await import('@/composables/useSession')
+    const answers = [makeAnswer(true), makeAnswer(true), makeAnswer(true)]
+    await completeSession(makeConfig(['ec2']), answers, Date.now() - 1000, db)
+    const topic = await db.topics.where('topicId').equals('ec2').first()
+    expect(topic!.rawScore).toBeGreaterThan(50)
+  })
+
+  it('0% correct session lowers rawScore', async () => {
+    await db.topics.bulkAdd([makeTopic({ topicId: 'ec2', rawScore: 80 })])
+    const { completeSession } = await import('@/composables/useSession')
+    const answers = [makeAnswer(false), makeAnswer(false), makeAnswer(false)]
+    await completeSession(makeConfig(['ec2']), answers, Date.now() - 1000, db)
+    const topic = await db.topics.where('topicId').equals('ec2').first()
+    expect(topic!.rawScore).toBeLessThan(80)
+  })
+
+  it('topics not in session are not modified', async () => {
+    const beforeTs = Date.now()
+    await db.topics.bulkAdd([
+      makeTopic({ topicId: 'ec2', rawScore: 50 }),
+      makeTopic({ topicId: 's3', rawScore: 60 }),
+    ])
+    const { completeSession } = await import('@/composables/useSession')
+    await completeSession(makeConfig(['ec2']), [makeAnswer(true)], Date.now() - 1000, db)
+    const s3 = await db.topics.where('topicId').equals('s3').first()
+    expect(s3?.rawScore).toBe(60)
+    expect(s3?.lastReviewedAt).toBeNull()
+  })
+
+  it('increments totalSessions for touched topics', async () => {
+    await db.topics.bulkAdd([makeTopic({ topicId: 'ec2', rawScore: 50, totalSessions: 2 })])
+    const { completeSession } = await import('@/composables/useSession')
+    await completeSession(makeConfig(['ec2']), [makeAnswer(true)], Date.now() - 1000, db)
+    const topic = await db.topics.where('topicId').equals('ec2').first()
+    expect(topic?.totalSessions).toBe(3)
+  })
+
+  it('persists session record to db.sessions', async () => {
+    await db.topics.bulkAdd([makeTopic({ topicId: 'ec2' })])
+    const { completeSession } = await import('@/composables/useSession')
+    await completeSession(makeConfig(['ec2']), [makeAnswer(true), makeAnswer(false)], Date.now() - 1000, db)
+    const sessions = await db.sessions.toArray()
+    expect(sessions.length).toBe(1)
+    expect(sessions[0].correctCount).toBe(1)
+    expect(sessions[0].totalQuestions).toBe(2)
   })
 })

--- a/src/views/SessionView.vue
+++ b/src/views/SessionView.vue
@@ -43,12 +43,14 @@
 import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { useSessionStore } from '@/stores/session'
+import { useTopicsStore } from '@/stores/topics'
 import { buildQuestionQueue, submitAnswer, completeSession } from '@/composables/useSession'
 import QuestionCard from '@/components/QuestionCard.vue'
 import ProgressBar from '@/components/ProgressBar.vue'
 
 const router = useRouter()
 const sessionStore = useSessionStore()
+const topicsStore = useTopicsStore()
 
 const currentAnswer = ref<number | null>(null)
 const feedbackDismissed = ref(false)
@@ -112,6 +114,7 @@ async function handleAdvance() {
 async function finish() {
   if (timerInterval) clearInterval(timerInterval)
   await completeSession(config.value!, sessionStore.answers, sessionStore.startedAt)
+  await topicsStore.refreshTopics()
   sessionStore.finishSession()
   router.replace('/study/session/review')
 }

--- a/src/views/__tests__/SessionView.spec.ts
+++ b/src/views/__tests__/SessionView.spec.ts
@@ -1,0 +1,116 @@
+import 'fake-indexeddb/auto'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { setActivePinia, createPinia } from 'pinia'
+import { createRouter, createWebHashHistory } from 'vue-router'
+import { useSessionStore } from '@/stores/session'
+import SessionView from '@/views/SessionView.vue'
+import type { SessionConfig, Question } from '@/types'
+
+const refreshTopics = vi.hoisted(() => vi.fn(async () => {}))
+
+vi.mock('@/composables/useSession', () => ({
+  buildQuestionQueue: vi.fn(async (): Promise<Question[]> => [
+    {
+      id: 1,
+      topicId: 'ec2',
+      text: 'Q1',
+      options: ['A', 'B', 'C', 'D'],
+      correctIndex: 0,
+      explanation: 'A is correct',
+      source: 'seed',
+      errorCount: 0,
+      lastSeenAt: null,
+      createdAt: Date.now(),
+    },
+  ]),
+  submitAnswer: vi.fn(async (_qId: number, idx: number, _t: number, correctIdx: number) => ({
+    questionId: 1,
+    selectedIndex: idx,
+    timeMs: 0,
+    correct: idx === correctIdx,
+  })),
+  completeSession: vi.fn(async () => {}),
+}))
+
+vi.mock('@/stores/topics', () => ({
+  useTopicsStore: vi.fn(() => ({ refreshTopics })),
+}))
+
+vi.mock('@/components/QuestionCard.vue', () => ({
+  default: {
+    name: 'QuestionCard',
+    props: ['question', 'selectedIndex', 'disabled', 'showFeedback'],
+    emits: ['select'],
+    template: '<div class="question-card" @click="$emit(\'select\', 0)"></div>',
+  },
+}))
+
+vi.mock('@/components/ProgressBar.vue', () => ({
+  default: { name: 'ProgressBar', props: ['current', 'total'], template: '<div />' },
+}))
+
+function mountSessionView() {
+  const router = createRouter({
+    history: createWebHashHistory(),
+    routes: [
+      { path: '/study/session', component: SessionView },
+      { path: '/study/session/review', component: { template: '<div>review</div>' } },
+      { path: '/study', component: { template: '<div>study</div>' } },
+    ],
+  })
+  router.push('/study/session')
+
+  return mount(SessionView, { global: { plugins: [router] } })
+}
+
+const baseConfig: SessionConfig = {
+  topicIds: ['ec2'],
+  mode: 'mixed',
+  questionCount: 1,
+  feedbackMode: 'exam',
+  timerEnabled: false,
+  timerSeconds: 0,
+}
+
+describe('SessionView', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('calls topicsStore.refreshTopics() after session completes', async () => {
+    const sessionStore = useSessionStore()
+    sessionStore.configure(baseConfig)
+
+    const wrapper = mountSessionView()
+    await flushPromises()
+
+    await wrapper.find('.question-card').trigger('click')
+    await flushPromises()
+
+    const btn = wrapper.find('.session-view__btn')
+    expect(btn.exists()).toBe(true)
+    await btn.trigger('click')
+    await flushPromises()
+
+    expect(refreshTopics).toHaveBeenCalledOnce()
+  })
+
+  it('sessionStore.status transitions to review after finish', async () => {
+    const sessionStore = useSessionStore()
+    sessionStore.configure(baseConfig)
+
+    const wrapper = mountSessionView()
+    await flushPromises()
+
+    await wrapper.find('.question-card').trigger('click')
+    await flushPromises()
+
+    const btn = wrapper.find('.session-view__btn')
+    await btn.trigger('click')
+    await flushPromises()
+
+    expect(sessionStore.status).toBe('review')
+  })
+})


### PR DESCRIPTION
## 🚀 Feature
- Wires completeSession() to update SR scores per topic after each session

### 📄 Summary
- completeSession() now calls SR update logic per topic touched
- Writes updated rawScore and lastReviewedAt back to db.topics
- Calls topicsStore.refreshTopics() after completion for immediate heatmap update
- sessionStore transitions to 'review' status after session completes

### 🌟 What's New
- Post-session SR score updates per topic
- Topics not in session are left unchanged
- Immediate heatmap color refresh without page reload

### 🧪 How to Test
- Run `npm run test` to verify tests pass
- Complete a 100% correct session — verify topic rawScore increases
- Complete a 0% correct session — verify topic rawScore decreases
- Verify topics not in the session are unchanged in db.topics

### 🖼️ UI Changes (if any)
- Topic tile colors update immediately after session completion

### 📌 Checklist
- [ ] Feature works as expected
- [ ] Unit/integration tests added (if applicable)
- [ ] Updated relevant documentation
- [ ] Verified in staging (if applicable)

Closes #10