### PR TITLE
feat(topics): topic detail view

### DIFF
--- a/src/views/TopicDetailView.vue
+++ b/src/views/TopicDetailView.vue
@@ -1,8 +1,204 @@
 <template>
   <main class="topic-detail-view">
-    <h1>Topic Detail</h1>
+    <header class="topic-detail-view__header">
+      <RouterLink to="/topics" class="topic-detail-view__back">← Topics</RouterLink>
+      <h1 class="topic-detail-view__title">{{ topic?.name }}</h1>
+    </header>
+
+    <section class="topic-detail-view__scores">
+      <div class="topic-detail-view__score-item" data-test="effective-score">
+        <span class="topic-detail-view__score-label">Effective Score</span>
+        <span class="topic-detail-view__score-value">{{ Math.round(computedEffectiveScore) }}%</span>
+      </div>
+      <div class="topic-detail-view__score-item" data-test="raw-score">
+        <span class="topic-detail-view__score-label">Raw Score</span>
+        <span class="topic-detail-view__score-value">{{ Math.round(topic?.rawScore ?? 0) }}%</span>
+      </div>
+    </section>
+
+    <section class="topic-detail-view__stats">
+      <div class="topic-detail-view__stat" data-test="total-questions">
+        <span class="topic-detail-view__stat-label">Total Questions</span>
+        <span class="topic-detail-view__stat-value">{{ totalQuestions }}</span>
+      </div>
+      <div class="topic-detail-view__stat" data-test="difficult-count">
+        <span class="topic-detail-view__stat-label">Difficult Questions</span>
+        <span class="topic-detail-view__stat-value">{{ difficultCount }}</span>
+      </div>
+    </section>
+
+    <section class="topic-detail-view__history">
+      <h2 class="topic-detail-view__history-title">Session History</h2>
+      <p v-if="sessionHistory.length === 0" class="topic-detail-view__empty">No sessions yet.</p>
+      <ul v-else class="topic-detail-view__history-list">
+        <li
+          v-for="session in sessionHistory"
+          :key="session.id"
+          class="topic-detail-view__history-item"
+          data-test="session-history-item"
+        >
+          <span class="topic-detail-view__session-date">{{ formatDate(session.startedAt) }}</span>
+          <span class="topic-detail-view__session-pct">{{ sessionPct(session) }}%</span>
+        </li>
+      </ul>
+    </section>
   </main>
 </template>
 
 <script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { db } from '@/db/db'
+import { effectiveScore } from '@/composables/useSpacedRepetition'
+import type { Topic, Session } from '@/types'
+
+const route = useRoute()
+const router = useRouter()
+
+const topic = ref<Topic | null>(null)
+const totalQuestions = ref(0)
+const difficultCount = ref(0)
+const sessionHistory = ref<Session[]>([])
+
+const computedEffectiveScore = computed(() =>
+  topic.value ? effectiveScore(topic.value.rawScore, topic.value.lastReviewedAt) : 0,
+)
+
+function sessionPct(session: Session): number {
+  if (session.totalQuestions === 0) return 0
+  return Math.round((session.correctCount / session.totalQuestions) * 100)
+}
+
+function formatDate(ts: number): string {
+  return new Date(ts).toLocaleDateString()
+}
+
+onMounted(async () => {
+  const topicId = route.params.id as string
+  const found = await db.topics.where('topicId').equals(topicId).first()
+  if (!found) {
+    router.replace('/topics')
+    return
+  }
+  topic.value = found
+
+  const [topicQuestions, sessions] = await Promise.all([
+    db.questions.where('topicId').equals(topicId).toArray(),
+    db.sessions.toArray(),
+  ])
+
+  totalQuestions.value = topicQuestions.length
+  difficultCount.value = topicQuestions.filter((q) => q.errorCount >= 2).length
+  sessionHistory.value = sessions
+    .filter((s) => s.topicIds.includes(topicId) && s.completedAt !== null)
+    .sort((a, b) => b.startedAt - a.startedAt)
+})
 </script>
+
+<style scoped>
+.topic-detail-view {
+  padding: 1rem;
+  padding-bottom: 4rem;
+
+  .topic-detail-view__back {
+    display: inline-block;
+    margin-bottom: 0.5rem;
+    color: inherit;
+    text-decoration: none;
+    font-size: 0.875rem;
+  }
+
+  .topic-detail-view__title {
+    margin: 0 0 1rem;
+  }
+
+  .topic-detail-view__scores {
+    display: flex;
+    gap: 1rem;
+    margin-bottom: 1rem;
+  }
+
+  .topic-detail-view__score-item {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    padding: 0.75rem;
+    border-radius: 8px;
+    background: #f5f5f5;
+  }
+
+  .topic-detail-view__score-label {
+    font-size: 0.75rem;
+    color: #666;
+  }
+
+  .topic-detail-view__score-value {
+    font-size: 1.5rem;
+    font-weight: 700;
+    margin-top: 0.25rem;
+  }
+
+  .topic-detail-view__stats {
+    display: flex;
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+  }
+
+  .topic-detail-view__stat {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    padding: 0.75rem;
+    border-radius: 8px;
+    background: #f5f5f5;
+  }
+
+  .topic-detail-view__stat-label {
+    font-size: 0.75rem;
+    color: #666;
+  }
+
+  .topic-detail-view__stat-value {
+    font-size: 1.5rem;
+    font-weight: 700;
+    margin-top: 0.25rem;
+  }
+
+  .topic-detail-view__history-title {
+    font-size: 1rem;
+    margin: 0 0 0.75rem;
+  }
+
+  .topic-detail-view__empty {
+    color: #888;
+    font-size: 0.875rem;
+  }
+
+  .topic-detail-view__history-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .topic-detail-view__history-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.625rem 0.75rem;
+    border-radius: 6px;
+    background: #f5f5f5;
+  }
+
+  .topic-detail-view__session-date {
+    font-size: 0.875rem;
+    color: #444;
+  }
+
+  .topic-detail-view__session-pct {
+    font-weight: 600;
+  }
+}
+</style>

--- a/src/views/__tests__/TopicDetailView.spec.ts
+++ b/src/views/__tests__/TopicDetailView.spec.ts
@@ -1,0 +1,213 @@
+import 'fake-indexeddb/auto'
+import { describe, it, expect, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createRouter, createWebHashHistory } from 'vue-router'
+import { createPinia, setActivePinia } from 'pinia'
+import { db } from '@/db/db'
+import { TOPIC_DEFINITIONS } from '@/data/topics'
+import TopicDetailView from '@/views/TopicDetailView.vue'
+
+const router = createRouter({
+  history: createWebHashHistory(),
+  routes: [
+    { path: '/topics', component: { template: '<div/>' } },
+    { path: '/topics/:id', component: TopicDetailView },
+  ],
+})
+
+async function flush() {
+  await flushPromises()
+  await flushPromises()
+}
+
+describe('TopicDetailView', () => {
+  beforeEach(async () => {
+    setActivePinia(createPinia())
+    await db.topics.clear()
+    await db.questions.clear()
+    await db.sessions.clear()
+    await db.topics.bulkAdd(TOPIC_DEFINITIONS.map((t) => ({ ...t })))
+  })
+
+  it('shows topic name', async () => {
+    await router.push('/topics/ec2')
+    await router.isReady()
+    const wrapper = mount(TopicDetailView, {
+      global: { plugins: [router, createPinia()] },
+    })
+    await flush()
+    expect(wrapper.text()).toContain('EC2')
+  })
+
+  it('shows effective score and raw score', async () => {
+    await db.topics
+      .where('topicId')
+      .equals('ec2')
+      .modify({ rawScore: 80, lastReviewedAt: Date.now() })
+    await router.push('/topics/ec2')
+    await router.isReady()
+    const wrapper = mount(TopicDetailView, {
+      global: { plugins: [router, createPinia()] },
+    })
+    await flush()
+    expect(wrapper.find('[data-test="raw-score"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="effective-score"]').exists()).toBe(true)
+  })
+
+  it('shows total question count for topic', async () => {
+    await db.questions.bulkAdd([
+      {
+        topicId: 'ec2',
+        text: 'Q1',
+        options: ['a', 'b', 'c', 'd'],
+        correctIndex: 0,
+        explanation: 'e',
+        source: 'seed',
+        errorCount: 0,
+        lastSeenAt: null,
+        createdAt: Date.now(),
+      },
+      {
+        topicId: 'ec2',
+        text: 'Q2',
+        options: ['a', 'b', 'c', 'd'],
+        correctIndex: 0,
+        explanation: 'e',
+        source: 'seed',
+        errorCount: 0,
+        lastSeenAt: null,
+        createdAt: Date.now(),
+      },
+      {
+        topicId: 's3',
+        text: 'Q3',
+        options: ['a', 'b', 'c', 'd'],
+        correctIndex: 0,
+        explanation: 'e',
+        source: 'seed',
+        errorCount: 0,
+        lastSeenAt: null,
+        createdAt: Date.now(),
+      },
+    ])
+    await router.push('/topics/ec2')
+    await router.isReady()
+    const wrapper = mount(TopicDetailView, {
+      global: { plugins: [router, createPinia()] },
+    })
+    await flush()
+    const el = wrapper.find('[data-test="total-questions"]')
+    expect(el.exists()).toBe(true)
+    expect(el.text()).toContain('2')
+  })
+
+  it('shows difficult question count (errorCount >= 2)', async () => {
+    await db.questions.bulkAdd([
+      {
+        topicId: 'ec2',
+        text: 'Q1',
+        options: ['a', 'b', 'c', 'd'],
+        correctIndex: 0,
+        explanation: 'e',
+        source: 'seed',
+        errorCount: 2,
+        lastSeenAt: null,
+        createdAt: Date.now(),
+      },
+      {
+        topicId: 'ec2',
+        text: 'Q2',
+        options: ['a', 'b', 'c', 'd'],
+        correctIndex: 0,
+        explanation: 'e',
+        source: 'seed',
+        errorCount: 3,
+        lastSeenAt: null,
+        createdAt: Date.now(),
+      },
+      {
+        topicId: 'ec2',
+        text: 'Q3',
+        options: ['a', 'b', 'c', 'd'],
+        correctIndex: 0,
+        explanation: 'e',
+        source: 'seed',
+        errorCount: 1,
+        lastSeenAt: null,
+        createdAt: Date.now(),
+      },
+    ])
+    await router.push('/topics/ec2')
+    await router.isReady()
+    const wrapper = mount(TopicDetailView, {
+      global: { plugins: [router, createPinia()] },
+    })
+    await flush()
+    const el = wrapper.find('[data-test="difficult-count"]')
+    expect(el.exists()).toBe(true)
+    expect(el.text()).toContain('2')
+  })
+
+  it('shows session history for sessions that included this topic', async () => {
+    const now = Date.now()
+    await db.sessions.bulkAdd([
+      {
+        startedAt: now - 86400000,
+        completedAt: now - 86390000,
+        mode: 'mixed',
+        topicIds: ['ec2', 's3'],
+        totalQuestions: 10,
+        correctCount: 8,
+        durationMs: 10000,
+      },
+      {
+        startedAt: now - 172800000,
+        completedAt: now - 172790000,
+        mode: 'mixed',
+        topicIds: ['s3'],
+        totalQuestions: 5,
+        correctCount: 3,
+        durationMs: 5000,
+      },
+    ])
+    await router.push('/topics/ec2')
+    await router.isReady()
+    const wrapper = mount(TopicDetailView, {
+      global: { plugins: [router, createPinia()] },
+    })
+    await flush()
+    const items = wrapper.findAll('[data-test="session-history-item"]')
+    expect(items).toHaveLength(1)
+  })
+
+  it('session history shows correct percentage', async () => {
+    const now = Date.now()
+    await db.sessions.add({
+      startedAt: now - 86400000,
+      completedAt: now - 86390000,
+      mode: 'mixed',
+      topicIds: ['ec2'],
+      totalQuestions: 10,
+      correctCount: 7,
+      durationMs: 10000,
+    })
+    await router.push('/topics/ec2')
+    await router.isReady()
+    const wrapper = mount(TopicDetailView, {
+      global: { plugins: [router, createPinia()] },
+    })
+    await flush()
+    const item = wrapper.find('[data-test="session-history-item"]')
+    expect(item.text()).toContain('70')
+  })
+
+  it('redirects to /topics for unknown topic id', async () => {
+    await router.push('/topics/nonexistent')
+    await router.isReady()
+    mount(TopicDetailView, {
+      global: { plugins: [router, createPinia()] },
+    })
+    await flush()
+    expect(router.currentRoute.value.path).toBe('/topics')
+  })
+})


### PR DESCRIPTION
## 🚀 Feature
- Implements topic detail view at /#/topics/:id

### 📄 Summary
- TopicDetailView shows topic name, effective/raw score, session history, question count, difficult count
- HeatmapGrid topic tiles now navigate to /#/topics/:id on click
- Nav guard redirects unknown topic ids back to /#/topics

### 🌟 What's New
- TopicDetailView.vue at /#/topics/:id route
- Per-topic session history (date + correct %)
- Difficult question count (errorCount >= 2)
- Click-through from HeatmapGrid tiles

### 🧪 How to Test
- Run `npm run test` to verify tests pass
- Click a topic tile — verify navigates to /#/topics/:id
- Verify effective score, raw score, session history, difficult count displayed
- Navigate to /#/topics/nonexistent — verify redirect

### 🖼️ UI Changes (if any)
- Topic tiles in HeatmapGrid are now clickable
- New TopicDetailView at /#/topics/:id

### 📌 Checklist
- [ ] Feature works as expected
- [ ] Unit/integration tests added (if applicable)
- [ ] Updated relevant documentation
- [ ] Verified in staging (if applicable)

Closes #13