### PR TITLE
chore(deploy): GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,34 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/src/composables/__tests__/useSession.spec.ts
+++ b/src/composables/__tests__/useSession.spec.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import 'fake-indexeddb/auto'
-import Dexie from 'dexie'
 import { ExamDB } from '@/db/db'
 import type { Question, Topic, SessionConfig } from '@/types'
 import type { AnswerRecord } from '@/composables/useSession'
@@ -228,7 +227,6 @@ describe('completeSession', () => {
   })
 
   it('topics not in session are not modified', async () => {
-    const beforeTs = Date.now()
     await db.topics.bulkAdd([
       makeTopic({ topicId: 'ec2', rawScore: 50 }),
       makeTopic({ topicId: 's3', rawScore: 60 }),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,8 @@ import vue from '@vitejs/plugin-vue'
 import { VitePWA } from 'vite-plugin-pwa'
 import { fileURLToPath, URL } from 'node:url'
 
-export default defineConfig({
+export default defineConfig(({ command }) => ({
+  base: command === 'build' ? '/exam-creator/' : '/',
   plugins: [
     vue(),
     VitePWA({
@@ -41,4 +42,4 @@ export default defineConfig({
       '@': fileURLToPath(new URL('./src', import.meta.url)),
     },
   },
-})
+}))


### PR DESCRIPTION
## 🚀 Feature
- Configures GitHub Pages deployment via GitHub Actions

### 📄 Summary
- vite.config.ts sets base: '/exam-creator/' for production builds
- deploy.yml workflow builds and deploys dist/ to GitHub Pages on push to main
- Hash routing ensures all /#/ routes work correctly on deployed URL

### 🌟 What's New
- .github/workflows/deploy.yml
- Production base path in vite.config.ts

### 🧪 How to Test
- Run `npm run build` — verify asset URLs include /exam-creator/ prefix
- Push to main — verify GitHub Actions workflow succeeds
- Visit GitHub Pages URL — verify app loads and hash routes work

### 🖼️ UI Changes (if any)
- None

### 📌 Checklist
- [ ] Feature works as expected
- [ ] Unit/integration tests added (if applicable)
- [ ] Updated relevant documentation
- [ ] Verified in staging (if applicable)

Closes #15