### PR TITLE
feat(design): answer feedback animations on QuestionCard

### DIFF
--- a/src/components/QuestionCard.vue
+++ b/src/components/QuestionCard.vue
@@ -47,6 +47,24 @@ const emit = defineEmits<{
 </script>
 
 <style scoped>
+@keyframes pulse-correct {
+  0%   { transform: scale(1); }
+  50%  { transform: scale(1.04); }
+  100% { transform: scale(1); }
+}
+
+@keyframes shake-incorrect {
+  0%, 100% { transform: translateX(0); }
+  20%       { transform: translateX(-6px); }
+  40%       { transform: translateX(6px); }
+  60%       { transform: translateX(-4px); }
+  80%       { transform: translateX(4px); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * { animation: none !important; transition: none !important; }
+}
+
 .question-card {
   display: flex;
   flex-direction: column;
@@ -73,13 +91,15 @@ const emit = defineEmits<{
     transition: background 0.15s;
 
     &--correct {
-      border-color: #22c55e;
-      background: #f0fdf4;
+      border-color: var(--color-success);
+      background: var(--color-success-light);
+      animation: pulse-correct 0.4s ease-in-out;
     }
 
     &--incorrect {
-      border-color: #ef4444;
-      background: #fef2f2;
+      border-color: var(--color-danger);
+      background: var(--color-danger-light);
+      animation: shake-incorrect 0.4s ease-in-out;
     }
   }
 

--- a/src/components/__tests__/QuestionCard.spec.ts
+++ b/src/components/__tests__/QuestionCard.spec.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import QuestionCard from '@/components/QuestionCard.vue'
+import type { Question } from '@/types'
+
+const mockQuestion: Question = {
+  id: 1,
+  topicId: 'ec2',
+  text: 'What is EC2?',
+  options: ['A virtual machine', 'A storage service', 'A database', 'A network service'],
+  correctIndex: 0,
+  explanation: 'EC2 is a virtual machine service.',
+  source: 'seed',
+  errorCount: 0,
+  lastSeenAt: null,
+  createdAt: Date.now(),
+}
+
+describe('QuestionCard', () => {
+  it('has no feedback classes before any selection', () => {
+    const wrapper = mount(QuestionCard, {
+      props: {
+        question: mockQuestion,
+        selectedIndex: null,
+        disabled: false,
+        showFeedback: false,
+      },
+    })
+    const options = wrapper.findAll('.question-card__option')
+    for (const option of options) {
+      expect(option.classes()).not.toContain('question-card__option--correct')
+      expect(option.classes()).not.toContain('question-card__option--incorrect')
+    }
+  })
+
+  it('applies --correct class to correct option after correct selection', () => {
+    const wrapper = mount(QuestionCard, {
+      props: {
+        question: mockQuestion,
+        selectedIndex: 0,
+        disabled: true,
+        showFeedback: true,
+      },
+    })
+    const options = wrapper.findAll('.question-card__option')
+    expect(options[0].classes()).toContain('question-card__option--correct')
+    expect(options[0].classes()).not.toContain('question-card__option--incorrect')
+  })
+
+  it('applies --incorrect class to wrong option and --correct to correct option after wrong selection', () => {
+    const wrapper = mount(QuestionCard, {
+      props: {
+        question: mockQuestion,
+        selectedIndex: 1,
+        disabled: true,
+        showFeedback: true,
+      },
+    })
+    const options = wrapper.findAll('.question-card__option')
+    expect(options[1].classes()).toContain('question-card__option--incorrect')
+    expect(options[0].classes()).toContain('question-card__option--correct')
+  })
+})

--- a/src/views/SessionReviewView.vue
+++ b/src/views/SessionReviewView.vue
@@ -1,9 +1,12 @@
 <template>
   <main class="session-review-view">
-    <header class="session-review-view__header">
+    <header class="session-review-view__header" :class="{ 'session-review-view__header--high-score': isHighScore }">
       <h1 class="session-review-view__title">Session Review</h1>
       <p class="session-review-view__score">
         {{ correctCount }} / {{ sessionStore.queue.length }} correct
+      </p>
+      <p v-if="isHighScore" class="session-review-view__celebration">
+        ★ Great job! You scored {{ scorePercent }}%!
       </p>
     </header>
 
@@ -53,6 +56,12 @@ const sessionStore = useSessionStore()
 const topicsStore = useTopicsStore()
 
 const correctCount = computed(() => sessionStore.answers.filter((a) => a.correct).length)
+const scorePercent = computed(() =>
+  sessionStore.queue.length > 0
+    ? Math.round((correctCount.value / sessionStore.queue.length) * 100)
+    : 0
+)
+const isHighScore = computed(() => scorePercent.value >= 80)
 
 function getSelectedIndex(questionIndex: number): number | null {
   return sessionStore.answers[questionIndex]?.selectedIndex ?? null
@@ -82,6 +91,14 @@ async function done() {
     display: flex;
     flex-direction: column;
     gap: 0.25rem;
+
+    &--high-score {
+      border: 2px solid var(--color-success);
+      border-radius: var(--radius-lg);
+      padding: 1rem;
+      background: var(--color-success-light);
+      box-shadow: 0 0 16px 0 rgb(34 197 94 / 0.25);
+    }
   }
 
   &__title {
@@ -92,6 +109,13 @@ async function done() {
   &__score {
     font-size: 1.1rem;
     color: #6b7280;
+  }
+
+  &__celebration {
+    font-size: 1rem;
+    font-weight: 600;
+    color: #15803d;
+    margin-top: 0.25rem;
   }
 
   &__list {


### PR DESCRIPTION
## 🚀 Feature
- CSS keyframe animations for answer feedback and high-score celebration.

### 📄 Summary
- Adds green pulse animation on correct answer selection
- Adds red shake animation on incorrect answer selection
- Highlights correct option after wrong selection
- Respects prefers-reduced-motion
- SessionReviewView shows celebratory emphasis for ≥80% scores

Closes #37

### 🌟 What's New
- Green scale/pulse keyframe on correct option selection
- Red horizontal shake keyframe on incorrect option selection
- Correct option highlighted green after wrong answer
- @media (prefers-reduced-motion: reduce) disables all animations
- High-score visual emphasis in SessionReviewView (≥80%)
- Unit tests for --correct/--incorrect BEM modifier classes

### 🧪 How to Test
- Run \`npm run build\` — should pass
- Run \`npm run test\` — should pass
- Answer a question correctly — green pulse animation on selected option
- Answer incorrectly — red shake on wrong, green highlight on correct
- Enable prefers-reduced-motion in OS — animations should not play
- Complete a session with ≥80% — celebratory emphasis in review

### 📌 Checklist
- [ ] Feature works as expected
- [ ] Unit/integration tests added (if applicable)
- [ ] Updated relevant documentation
- [ ] Verified in staging (if applicable)