### PR TITLE
feat(design): empty state component for topics and detail

### DIFF
--- a/src/components/EmptyState.vue
+++ b/src/components/EmptyState.vue
@@ -1,0 +1,56 @@
+<script setup lang="ts">
+import Button from 'primevue/button'
+
+defineProps<{
+  icon: string
+  heading: string
+  description: string
+  ctaLabel: string
+}>()
+
+const emit = defineEmits<{ cta: [] }>()
+</script>
+
+<template>
+  <section class="empty-state">
+    <span class="empty-state__icon">{{ icon }}</span>
+    <h2 class="empty-state__heading">{{ heading }}</h2>
+    <p class="empty-state__description">{{ description }}</p>
+    <Button class="empty-state__cta" :label="ctaLabel" @click="emit('cta')" />
+  </section>
+</template>
+
+<style scoped>
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-12) var(--space-6);
+  text-align: center;
+  gap: var(--space-4);
+
+  .empty-state__icon {
+    font-size: 3rem;
+    line-height: 1;
+  }
+
+  .empty-state__heading {
+    margin: 0;
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: var(--color-text);
+  }
+
+  .empty-state__description {
+    margin: 0;
+    font-size: 0.9375rem;
+    color: var(--color-text-muted);
+    max-width: 28ch;
+  }
+
+  .empty-state__cta {
+    margin-top: var(--space-2);
+  }
+}
+</style>

--- a/src/components/__tests__/EmptyState.spec.ts
+++ b/src/components/__tests__/EmptyState.spec.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import EmptyState from '@/components/EmptyState.vue'
+
+const defaultProps = {
+  icon: '📚',
+  heading: 'No topics yet',
+  description: 'Your topics will appear here.',
+  ctaLabel: 'Refresh',
+}
+
+describe('EmptyState', () => {
+  it('renders icon, heading, description, and cta label from props', () => {
+    const wrapper = mount(EmptyState, { props: defaultProps })
+    expect(wrapper.find('.empty-state__icon').text()).toBe('📚')
+    expect(wrapper.find('.empty-state__heading').text()).toBe('No topics yet')
+    expect(wrapper.find('.empty-state__description').text()).toBe('Your topics will appear here.')
+    expect(wrapper.find('.empty-state__cta').text()).toBe('Refresh')
+  })
+
+  it('emits cta event when CTA button is clicked', async () => {
+    const wrapper = mount(EmptyState, { props: defaultProps })
+    await wrapper.find('.empty-state__cta').trigger('click')
+    expect(wrapper.emitted('cta')).toHaveLength(1)
+  })
+})

--- a/src/views/TopicDetailView.vue
+++ b/src/views/TopicDetailView.vue
@@ -27,7 +27,16 @@
       </div>
     </section>
 
-    <section class="topic-detail-view__history">
+    <EmptyState
+      v-if="totalQuestions === 0"
+      icon="🧩"
+      heading="No questions yet"
+      description="Generate questions for this topic to start studying."
+      cta-label="Go to Study"
+      @cta="router.push('/study')"
+    />
+
+    <section v-else class="topic-detail-view__history">
       <h2 class="topic-detail-view__history-title">Session History</h2>
       <p v-if="sessionHistory.length === 0" class="topic-detail-view__empty">No sessions yet.</p>
       <ul v-else class="topic-detail-view__history-list">
@@ -50,6 +59,7 @@ import { ref, computed, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { db } from '@/db/db'
 import { effectiveScore } from '@/composables/useSpacedRepetition'
+import EmptyState from '@/components/EmptyState.vue'
 import type { Topic, Session } from '@/types'
 
 const route = useRoute()

--- a/src/views/TopicsView.vue
+++ b/src/views/TopicsView.vue
@@ -1,13 +1,22 @@
 <template>
   <main class="topics-view">
     <h1 class="topics-view__title">Topics</h1>
-    <HeatmapGrid :topics="store.topicsWithEffectiveScore" />
+    <EmptyState
+      v-if="store.topicsWithEffectiveScore.length === 0"
+      icon="📚"
+      heading="No topics yet"
+      description="Your topics will appear here once they've been seeded."
+      cta-label="Refresh"
+      @cta="store.refreshTopics()"
+    />
+    <HeatmapGrid v-else :topics="store.topicsWithEffectiveScore" />
   </main>
 </template>
 
 <script setup lang="ts">
 import { onMounted } from 'vue'
 import HeatmapGrid from '@/components/HeatmapGrid.vue'
+import EmptyState from '@/components/EmptyState.vue'
 import { useTopicsStore } from '@/stores/topics'
 
 const store = useTopicsStore()

--- a/src/views/__tests__/TopicDetailView.spec.ts
+++ b/src/views/__tests__/TopicDetailView.spec.ts
@@ -27,6 +27,17 @@ describe('TopicDetailView', () => {
     await db.questions.clear()
     await db.sessions.clear()
     await db.topics.bulkAdd(TOPIC_DEFINITIONS.map((t) => ({ ...t })))
+    await db.questions.add({
+      topicId: 'ec2',
+      text: 'Default Q',
+      options: ['a', 'b', 'c', 'd'],
+      correctIndex: 0,
+      explanation: 'e',
+      source: 'seed',
+      errorCount: 0,
+      lastSeenAt: null,
+      createdAt: Date.now(),
+    })
   })
 
   it('shows topic name', async () => {
@@ -98,7 +109,8 @@ describe('TopicDetailView', () => {
     await flush()
     const el = wrapper.find('[data-test="total-questions"]')
     expect(el.exists()).toBe(true)
-    expect(el.text()).toContain('2')
+    // beforeEach adds 1 default ec2 question; this test adds 2 more = 3 total
+    expect(el.text()).toContain('3')
   })
 
   it('shows difficult question count (errorCount >= 2)', async () => {
@@ -209,5 +221,26 @@ describe('TopicDetailView', () => {
     })
     await flush()
     expect(router.currentRoute.value.path).toBe('/topics')
+  })
+
+  it('shows EmptyState when topic has no questions', async () => {
+    await db.questions.clear()
+    await router.push('/topics/ec2')
+    await router.isReady()
+    const wrapper = mount(TopicDetailView, {
+      global: { plugins: [router, createPinia()] },
+    })
+    await flush()
+    expect(wrapper.find('.empty-state').exists()).toBe(true)
+  })
+
+  it('does not show EmptyState when topic has questions', async () => {
+    await router.push('/topics/ec2')
+    await router.isReady()
+    const wrapper = mount(TopicDetailView, {
+      global: { plugins: [router, createPinia()] },
+    })
+    await flush()
+    expect(wrapper.find('.empty-state').exists()).toBe(false)
   })
 })

--- a/src/views/__tests__/TopicsView.spec.ts
+++ b/src/views/__tests__/TopicsView.spec.ts
@@ -41,4 +41,26 @@ describe('TopicsView', () => {
     await flushPromises()
     expect(wrapper.findAll('.topic-tile')).toHaveLength(17)
   })
+
+  it('shows EmptyState when topics list is empty', async () => {
+    await db.topics.clear()
+    await router.push('/topics')
+    await router.isReady()
+    const wrapper = mount(TopicsView, {
+      global: { plugins: [router, createPinia()] },
+    })
+    await flushPromises()
+    expect(wrapper.find('.empty-state').exists()).toBe(true)
+    expect(wrapper.find('.heatmap-grid').exists()).toBe(false)
+  })
+
+  it('does not show EmptyState when topics exist', async () => {
+    await router.push('/topics')
+    await router.isReady()
+    const wrapper = mount(TopicsView, {
+      global: { plugins: [router, createPinia()] },
+    })
+    await flushPromises()
+    expect(wrapper.find('.empty-state').exists()).toBe(false)
+  })
 })


### PR DESCRIPTION
## 🚀 Feature
- Reusable EmptyState component for topics and topic detail views.

### 📄 Summary
- Creates EmptyState.vue with icon, heading, description, and CTA props
- Integrates into TopicsView (empty topics list) and TopicDetailView (no questions)
- CTA uses PrimeVue Button with orange palette

Closes #36

### 🌟 What's New
- New `EmptyState.vue` component with icon/heading/description/ctaLabel props
- Emits `cta` event on CTA button click
- TopicsView shows EmptyState when no topics exist
- TopicDetailView shows EmptyState when topic has no questions
- Unit tests covering props, event emission, and conditional rendering

### 🧪 How to Test
- Run `npm run build` — should pass
- Run `npm run test` — should pass
- Open app with no topics — EmptyState should appear in TopicsView
- Open a topic with no questions — EmptyState should appear in TopicDetailView

### 📌 Checklist
- [ ] Feature works as expected
- [ ] Unit/integration tests added (if applicable)
- [ ] Updated relevant documentation
- [ ] Verified in staging (if applicable)