### PR TITLE
docs(theme): add PRD, RUNBOOK, and TRACKER for theme toggle feature

### DIFF
--- a/docs/THEME_TOGGLE_3/PRD.md
+++ b/docs/THEME_TOGGLE_3/PRD.md
@@ -1,0 +1,76 @@
+# PRD: Theme Toggle — Light, Dark, and Auto Mode
+
+## Problem Statement
+
+The app currently applies dark mode exclusively via `@media (prefers-color-scheme: dark)` in `tokens.css`, meaning it always follows the OS setting with no way for the user to override it. Users who prefer a light theme on a dark-OS device (or vice versa) have no recourse. A manual theme toggle in Settings gives users direct control over their visual experience without requiring an OS-level change.
+
+## Solution
+
+Add a `theme` preference (`'light' | 'dark' | 'auto'`) to the settings store and persist it in the existing IndexedDB `settings` table. Apply the preference reactively in `App.vue` by writing a `data-theme` attribute to `<html>`. Update `tokens.css` to honour both `[data-theme='dark']` and `@media (prefers-color-scheme: dark)` (the latter as the fallback when `auto` is selected). Expose a 3-option segmented control (Light / Auto / Dark) in `SettingsView` — no Save button needed since the change applies instantly.
+
+## User Stories
+
+1. As a student, I want to manually set the app to light mode, so that I can use it comfortably even when my OS is in dark mode.
+2. As a student, I want to manually set the app to dark mode, so that I can use it comfortably even when my OS is in light mode.
+3. As a student, I want an "Auto" option that follows my OS setting, so that I don't have to think about it if I'm happy with the default behaviour.
+4. As a student, I want the theme to apply instantly when I tap a mode, so that I get immediate visual feedback without needing to save and reload.
+5. As a student, I want my theme preference to persist across sessions, so that I don't have to re-set it every time I open the app.
+
+## Acceptance Criteria
+
+- `SettingsView` shows a 3-option segmented control: **Light | Auto | Dark**
+- Selecting a mode applies the theme immediately (no Save button)
+- `'light'` — forces light tokens regardless of OS
+- `'dark'` — forces dark tokens regardless of OS
+- `'auto'` — defers to `prefers-color-scheme` (existing behaviour)
+- Selected preference is persisted to IndexedDB (`key: 'theme'`) and survives app reload
+- `settingsStore` exposes `theme` ref and `saveTheme(value)` action
+- `tokens.css` dark-mode block responds to both `[data-theme='dark']` and `@media (prefers-color-scheme: dark)` without duplication (use a SCSS mixin or selector list)
+- `[data-theme='light']` explicitly overrides any OS dark preference
+- `App.vue` watches `settingsStore.theme` and writes `document.documentElement.dataset.theme` accordingly (`'light'` or `'dark'`); removes the attribute when `'auto'`
+- `npm run build` and `npm run test` pass
+
+## Technical Approach
+
+### 1. `tokens.css` — dark token block
+Apply dark tokens under both selectors:
+```css
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme='light']) { /* dark token overrides */ }
+}
+
+[data-theme='dark'] { /* same dark token overrides */ }
+```
+This means:
+- OS dark + no attribute → `:root:not([data-theme='light'])` matches → dark
+- OS dark + `data-theme='light'` → `:not` excludes it → light
+- `data-theme='dark'` → always dark regardless of OS
+
+### 2. `settingsStore`
+Add `theme` ref (default `'auto'`) and `saveTheme(value: ThemePreference)` that persists to `db.settings`.
+
+### 3. `App.vue`
+Use a `watchEffect` (or `computed` side-effect in `onMounted` + watch) to sync `settingsStore.theme` → `document.documentElement.dataset.theme`:
+```ts
+watchEffect(() => {
+  const t = settingsStore.theme
+  if (t === 'auto') delete document.documentElement.dataset.theme
+  else document.documentElement.dataset.theme = t
+})
+```
+
+### 4. `SettingsView`
+Add an "Appearance" section above API Key using PrimeVue `ButtonGroup` + `Button :outlined` (same pattern as the Mode group in StudyView):
+```html
+<ButtonGroup>
+  <Button label="Light" :outlined="theme !== 'light'" @click="setTheme('light')" />
+  <Button label="Auto"  :outlined="theme !== 'auto'"  @click="setTheme('auto')"  />
+  <Button label="Dark"  :outlined="theme !== 'dark'"  @click="setTheme('dark')"  />
+</ButtonGroup>
+```
+
+## Out of Scope
+
+- Per-view or per-component theme overrides
+- Custom colour palette picker
+- Scheduled theme switching (e.g. auto-dark after sunset)

--- a/docs/THEME_TOGGLE_3/RUNBOOK.md
+++ b/docs/THEME_TOGGLE_3/RUNBOOK.md
@@ -1,0 +1,126 @@
+# RUNBOOK: Theme Toggle Execution
+
+Drives both GitHub issues via dependency-ordered waves. Each wave spawns
+isolated agents that implement features using `/tdd`, then open PRs for review.
+
+**Rule:** Merge all PRs in wave N before starting wave N+1.
+
+---
+
+## Dependency Wave Map
+
+| Wave | Issues | Parallel | Blocked by |
+|------|--------|----------|------------|
+| 1 | #52 | — | — |
+| 2 | #53 | — | #52 |
+
+---
+
+## How to use
+
+1. Copy a prompt block below
+2. Paste into your Claude Code session and press Enter
+3. Claude spawns an isolated agent with its own git worktree
+4. The agent runs `/tdd` until tests pass, then opens a PR
+5. Review and merge the PR, then move to the next wave
+
+---
+
+## Wave 1 — #52: Theme switching engine
+
+**Prerequisite:** None
+
+```
+Spawn an agent with isolation: "worktree" to implement GitHub issue #52.
+
+Branch: issue/52  |  PR target: main
+
+== ISSUE: feat(theme): theme switching engine — tokens, store, App.vue wiring ==
+
+What to build:
+Update `tokens.css` to support manual theme overrides via a `data-theme`
+attribute on `<html>`. Extend `settingsStore` with a `theme` preference
+and wire `App.vue` to reactively apply it.
+
+Changes required:
+- Add `ThemePreference = 'light' | 'dark' | 'auto'` to `src/types/index.ts`
+- Update `tokens.css` dark block:
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-theme='light']) { /* existing dark token overrides */ }
+    }
+    [data-theme='dark'] { /* same dark token overrides */ }
+- Add `theme` ref (default 'auto') and `saveTheme(value: ThemePreference)`
+  to `settingsStore`; persist to `db.settings` key 'theme'
+- Update `settingsStore.loadFromDB()` to hydrate the `theme` ref
+- Add `watchEffect` in `App.vue` that sets/removes
+  `document.documentElement.dataset.theme` based on `settingsStore.theme`
+
+Acceptance criteria:
+- `ThemePreference` type exported from `src/types/index.ts`
+- `tokens.css` dark tokens apply under both `[data-theme='dark']` and
+  `@media (prefers-color-scheme: dark)` without duplication
+- `[data-theme='light']` on `<html>` forces light tokens even when OS is dark
+- `settingsStore` exposes `theme` ref and `saveTheme()` action
+- `loadFromDB()` hydrates `theme` from the `'theme'` settings key
+- `App.vue` watchEffect syncs store → `document.documentElement.dataset.theme`
+- `npm run build` and `npm run test` pass
+
+PRD context: docs/THEME_TOGGLE_3/PRD.md
+
+Instructions:
+1. Create branch issue/52 from main
+2. Run `/tdd` — stop when tests and build pass cleanly
+3. Open a PR to main titled: feat(theme): theme switching engine — tokens, store, App.vue wiring
+4. Include "Closes #52" in the PR body
+```
+
+---
+
+## Wave 2 — #53: Appearance UI in SettingsView
+
+**Prerequisite:** #52 merged
+
+```
+Spawn an agent with isolation: "worktree" to implement GitHub issue #53.
+
+Branch: issue/53  |  PR target: main
+
+== ISSUE: feat(theme): appearance UI in SettingsView — Light / Auto / Dark segmented control ==
+
+What to build:
+Add an "Appearance" section to `SettingsView` with a PrimeVue `ButtonGroup`
+segmented control (Light | Auto | Dark). Clicking a button applies and
+persists the theme immediately — no Save button required.
+
+Changes required:
+- Add "Appearance" section above the API Key section in `SettingsView`
+- Use PrimeVue `ButtonGroup` + `Button` with `:outlined="theme !== value"`
+  pattern (same as Mode group in `StudyView`)
+- On click: call `settingsStore.saveTheme(value)` immediately
+- Initialise selected state from `settingsStore.theme` on mount
+
+Acceptance criteria:
+- "Appearance" section visible in SettingsView with Light / Auto / Dark buttons
+- Active option renders filled; inactive options are outlined
+- Clicking any option applies the theme instantly (no Save button)
+- Selected state is correctly initialised from persisted store value on mount
+- Unit test: each of the 3 buttons sets the correct theme value
+- `npm run build` and `npm run test` pass
+
+PRD context: docs/THEME_TOGGLE_3/PRD.md
+
+Instructions:
+1. Create branch issue/53 from main (ensure #52 is merged first)
+2. Run `/tdd` — stop when tests and build pass cleanly
+3. Open a PR to main titled: feat(theme): appearance UI in SettingsView — Light / Auto / Dark segmented control
+4. Include "Closes #53" in the PR body
+```
+
+---
+
+## Quick reference
+
+| Wave | Paste N prompts | Merge PRs | Then |
+|------|----------------|-----------|------|
+| 1 | 1 | #52 | → wave 2 |
+| 2 | 1 | #53 | done |

--- a/docs/THEME_TOGGLE_3/TRACKER.md
+++ b/docs/THEME_TOGGLE_3/TRACKER.md
@@ -1,0 +1,17 @@
+# Tracker: Theme Toggle — Light, Dark, and Auto Mode
+
+Parent PRD: #51
+
+## Issues
+
+| # | Title | Type | Blocked by | Status |
+|---|-------|------|------------|--------|
+| [#52](https://github.com/jayfalconiii/exam-creator/issues/52) | feat(theme): theme switching engine — tokens, store, App.vue wiring | AFK | None | Open |
+| [#53](https://github.com/jayfalconiii/exam-creator/issues/53) | feat(theme): appearance UI in SettingsView — Light / Auto / Dark segmented control | AFK | #52 | Open |
+
+## Dependency Graph
+
+```
+#52 theme switching engine
+ └── #53 appearance UI in SettingsView
+```


### PR DESCRIPTION
## 🚀 Feature
- Add planning docs for the Light / Auto / Dark theme toggle feature.

### 📄 Summary
- PRD defines the feature scope, technical approach, and acceptance criteria
- TRACKER links to GitHub issues #51, #52, #53
- RUNBOOK provides wave-based agent spawn prompts for implementation

### 🌟 What's New
- `docs/THEME_TOGGLE_3/PRD.md` — full product requirements doc
- `docs/THEME_TOGGLE_3/TRACKER.md` — issue tracker with links to #51, #52, #53
- `docs/THEME_TOGGLE_3/RUNBOOK.md` — copy-paste agent prompts for Wave 1 (#52) and Wave 2 (#53)

### 🧪 How to Test
- Review docs for accuracy against GitHub issues #51–#53

### 📌 Checklist
- [x] Feature works as expected
- [ ] Unit/integration tests added (if applicable)
- [x] Updated relevant documentation
- [ ] Verified in staging (if applicable)