### PR TITLE
feat(theme): appearance UI in SettingsView — Light / Auto / Dark segmented control

### DIFF
--- a/src/__tests__/SettingsView.spec.ts
+++ b/src/__tests__/SettingsView.spec.ts
@@ -3,21 +3,24 @@ import { mount, flushPromises } from '@vue/test-utils'
 import { createRouter, createWebHashHistory } from 'vue-router'
 import { createPinia, setActivePinia } from 'pinia'
 import PrimeVue from 'primevue/config'
-import type { SessionMode } from '@/types'
+import type { SessionMode, ThemePreference } from '@/types'
 import SettingsView from '@/views/SettingsView.vue'
 import HomeView from '@/views/HomeView.vue'
 
 const mockSaveApiKey = vi.fn().mockResolvedValue(undefined)
 const mockSaveDefaults = vi.fn().mockResolvedValue(undefined)
+const mockSaveTheme = vi.fn().mockResolvedValue(undefined)
 const mockLoadFromDB = vi.fn().mockResolvedValue(undefined)
 
 const mockStoreState = {
   apiKey: '',
   defaultQuestionCount: 10,
   defaultMode: 'mixed' as SessionMode,
+  theme: 'auto' as ThemePreference,
   hasApiKey: false,
   saveApiKey: mockSaveApiKey,
   saveDefaults: mockSaveDefaults,
+  saveTheme: mockSaveTheme,
   loadFromDB: mockLoadFromDB,
 }
 
@@ -42,9 +45,11 @@ describe('SettingsView', () => {
     mockStoreState.apiKey = ''
     mockStoreState.defaultQuestionCount = 10
     mockStoreState.defaultMode = 'mixed'
+    mockStoreState.theme = 'auto'
     mockStoreState.hasApiKey = false
     mockSaveApiKey.mockResolvedValue(undefined)
     mockSaveDefaults.mockResolvedValue(undefined)
+    mockSaveTheme.mockResolvedValue(undefined)
     mockLoadFromDB.mockResolvedValue(undefined)
   })
 
@@ -118,6 +123,36 @@ describe('SettingsView', () => {
 
     expect(mockSaveDefaults).toHaveBeenCalledWith(30, 'new')
     expect(wrapper.find('[data-testid="defaults-saved-msg"]').exists()).toBe(true)
+  })
+
+  it('clicking Light calls saveTheme with "light"', async () => {
+    const router = makeRouter()
+    const wrapper = mount(SettingsView, { global: { plugins: [router, createPinia(), PrimeVue] } })
+    await flushPromises()
+    const buttons = wrapper.findAll('button')
+    const lightBtn = buttons.find(b => b.text() === 'Light')
+    await lightBtn!.trigger('click')
+    expect(mockSaveTheme).toHaveBeenCalledWith('light')
+  })
+
+  it('clicking Auto calls saveTheme with "auto"', async () => {
+    const router = makeRouter()
+    const wrapper = mount(SettingsView, { global: { plugins: [router, createPinia(), PrimeVue] } })
+    await flushPromises()
+    const buttons = wrapper.findAll('button')
+    const autoBtn = buttons.find(b => b.text() === 'Auto')
+    await autoBtn!.trigger('click')
+    expect(mockSaveTheme).toHaveBeenCalledWith('auto')
+  })
+
+  it('clicking Dark calls saveTheme with "dark"', async () => {
+    const router = makeRouter()
+    const wrapper = mount(SettingsView, { global: { plugins: [router, createPinia(), PrimeVue] } })
+    await flushPromises()
+    const buttons = wrapper.findAll('button')
+    const darkBtn = buttons.find(b => b.text() === 'Dark')
+    await darkBtn!.trigger('click')
+    expect(mockSaveTheme).toHaveBeenCalledWith('dark')
   })
 })
 

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -5,6 +5,19 @@
     </header>
 
     <section class="settings-view__section">
+      <h2 class="settings-view__section-title">Appearance</h2>
+      <ButtonGroup class="settings-view__theme-group">
+        <Button
+          v-for="option in themeOptions"
+          :key="option.value"
+          :label="option.label"
+          :outlined="settingsStore.theme !== option.value"
+          @click="settingsStore.saveTheme(option.value)"
+        />
+      </ButtonGroup>
+    </section>
+
+    <section class="settings-view__section">
       <h2 class="settings-view__section-title">API Key</h2>
       <div class="settings-view__field">
         <label for="api-key-input">Anthropic API Key</label>
@@ -70,36 +83,43 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
 import Button from 'primevue/button'
+import ButtonGroup from 'primevue/buttongroup'
 import InputText from 'primevue/inputtext'
 import { useSettingsStore } from '@/stores/settings'
-import type { SessionMode } from '@/types'
+import type { SessionMode, ThemePreference } from '@/types'
 
-const store = useSettingsStore()
+const settingsStore = useSettingsStore()
+
+const themeOptions = [
+  { label: 'Light', value: 'light' as ThemePreference },
+  { label: 'Auto', value: 'auto' as ThemePreference },
+  { label: 'Dark', value: 'dark' as ThemePreference },
+]
 
 const apiKeyInput = ref('')
 const apiKeySaved = ref(false)
-const questionCountInput = ref(store.defaultQuestionCount)
+const questionCountInput = ref(settingsStore.defaultQuestionCount)
 const questionCountInputStr = computed({
   get: () => String(questionCountInput.value),
   set: (v) => { questionCountInput.value = Number(v) },
 })
-const modeInput = ref<SessionMode>(store.defaultMode)
+const modeInput = ref<SessionMode>(settingsStore.defaultMode)
 const defaultsSaved = ref(false)
 
 onMounted(async () => {
-  await store.loadFromDB()
-  apiKeyInput.value = store.apiKey
-  questionCountInput.value = store.defaultQuestionCount
-  modeInput.value = store.defaultMode
+  await settingsStore.loadFromDB()
+  apiKeyInput.value = settingsStore.apiKey
+  questionCountInput.value = settingsStore.defaultQuestionCount
+  modeInput.value = settingsStore.defaultMode
 })
 
 async function handleSaveApiKey() {
-  await store.saveApiKey(apiKeyInput.value)
+  await settingsStore.saveApiKey(apiKeyInput.value)
   apiKeySaved.value = true
 }
 
 async function handleSaveDefaults() {
-  await store.saveDefaults(questionCountInput.value, modeInput.value)
+  await settingsStore.saveDefaults(questionCountInput.value, modeInput.value)
   defaultsSaved.value = true
 }
 </script>
@@ -151,6 +171,15 @@ async function handleSaveDefaults() {
     &:focus {
       outline: 2px solid var(--color-primary);
       outline-offset: 1px;
+    }
+  }
+
+  &__theme-group {
+    width: 100%;
+
+    .p-button {
+      flex: 1;
+      min-height: 44px;
     }
   }
 


### PR DESCRIPTION
## 🚀 Feature
- Add Appearance section to SettingsView with Light / Auto / Dark segmented control.

### 📄 Summary
- PrimeVue ButtonGroup with 3 buttons (Light, Auto, Dark) above the API Key section
- Active option renders filled; inactive options are outlined
- Clicking immediately calls `settingsStore.saveTheme()` — no Save button needed
- Selected state initialised from persisted `settingsStore.theme` on mount

### 🌟 What's New
- `SettingsView.vue` — Appearance section with theme segmented control

### 🧪 How to Test
- Open Settings — Appearance section should be visible above API Key
- Click Light → page switches to light theme immediately
- Click Dark → page switches to dark theme immediately
- Click Auto → page follows OS preference
- Reload page — selected theme should persist

### 📌 Checklist
- [ ] Feature works as expected
- [ ] Unit/integration tests added (if applicable)
- [ ] Updated relevant documentation
- [ ] Verified in staging (if applicable)

Closes #53