### PR TITLE
docs(library): PRD, RUNBOOK, and TRACKER for question library feature

### DIFF
--- a/docs/QUESTION_LIBRARY_04/PRD.md
+++ b/docs/QUESTION_LIBRARY_04/PRD.md
@@ -1,0 +1,130 @@
+# Question Library
+
+## Problem Statement
+
+The app ships with a fixed seed question bank of ~200 AWS SAA-C03 questions and supports AI-generated questions via the Anthropic API. However, the user does not have an API key and does not want to pay for one. The in-app generation feature is therefore inaccessible, leaving the question bank static and limited. There is no way to expand, correct, or manage questions once the app is installed — questions cannot be added, edited, or deleted through any UI.
+
+## Solution
+
+A dedicated **Library** tab in the bottom navigation bar that gives the user full control over their question bank:
+
+- Browse all questions with filtering by AWS topic
+- Add individual questions via a manual input form
+- Bulk-import questions from a JSON or CSV file (generated externally, e.g. via Claude.ai)
+- Edit any existing question's fields
+- Delete questions individually
+
+The remote database and in-app AI generation remain out of scope. All data continues to live in local IndexedDB (Dexie). The user generates question content externally using their Claude.ai subscription and imports it into the app.
+
+## User Stories
+
+1. As a student, I want a Library tab in the bottom navigation, so that I can access question management without leaving the main app flow.
+2. As a student, I want to see a list of all questions in my bank, so that I can understand what content I have available.
+3. As a student, I want to filter the question list by AWS topic, so that I can quickly find questions relevant to a specific domain.
+4. As a student, I want to see each question's topic, text (truncated), and question count per topic, so that I can assess coverage at a glance.
+5. As a student, I want to tap a question in the list to open it in an edit form, so that I can correct mistakes or improve wording.
+6. As a student, I want to edit any field of a question (topic, text, options, correct answer, explanation), so that I can fix errors in seed or imported questions.
+7. As a student, I want to delete a question from the list, so that I can remove duplicates or low-quality questions.
+8. As a student, I want a confirmation step before deleting a question, so that I don't accidentally lose data.
+9. As a student, I want an "Add question" button that opens a blank form, so that I can manually author new questions one at a time.
+10. As a student, I want the add form to have a topic dropdown populated from existing topics, so that I don't mistype topic identifiers.
+11. As a student, I want the add form to have a text area for the question, four option inputs, a correct-answer selector, and an explanation field, so that every required field is captured.
+12. As a student, I want form validation to prevent saving incomplete questions, so that malformed questions don't break the study flow.
+13. As a student, I want an "Import" action in the Library, so that I can bulk-add questions I generated outside the app.
+14. As a student, I want to paste a JSON array of questions into the import dialog, so that I can quickly import questions copied from Claude.ai.
+15. As a student, I want to upload a CSV file in the import dialog, so that I can import questions from a spreadsheet.
+16. As a student, I want the import dialog to show me how many valid questions were found before I confirm, so that I can catch formatting errors early.
+17. As a student, I want invalid rows/items in an import to be reported with a clear error message, so that I know exactly what to fix.
+18. As a student, I want successfully imported questions to appear in my question list immediately, so that I can verify the import worked.
+19. As a student, I want imported questions to be tagged as `source: 'generated'`, so that they are treated the same as API-generated questions by the study engine.
+20. As a student, I want the Library to show a total question count and a per-topic breakdown, so that I can track my bank size over time.
+
+## Implementation Decisions
+
+### Modules
+
+**LibraryView**
+- New top-level route at `/library`, accessible from the bottom nav.
+- Loads all questions from `db.questions` on mount; re-loads after any mutation.
+- Maintains a local reactive filter (selected topic) to display a filtered subset.
+- Renders a scrollable list of question cards with topic badge, truncated text, edit button, and delete button.
+- Hosts the import dialog as a child component (toggled via a local boolean).
+- Header contains "Add" and "Import" action buttons.
+
+**QuestionFormView**
+- Shared view for both add (`/library/new`) and edit (`/library/:id/edit`) modes.
+- Detects mode from the presence of the `:id` route param.
+- In edit mode: loads the question by ID from `db.questions.get(id)` on mount.
+- In add mode: starts with a blank form state.
+- Topic field: dropdown populated by `db.topics.toArray()` on mount.
+- Options: four separate input fields (A–D); correct answer chosen via radio button group.
+- On save: calls `db.questions.add` (add mode) or `db.questions.update` (edit mode), then navigates back to `/library`.
+- Cancel navigates back without saving.
+
+**ImportDialog**
+- Modal/dialog component rendered inside LibraryView.
+- Tab toggle between JSON and CSV modes.
+- JSON mode: multiline textarea; on parse, validates each item against the `Question` shape (`topicId`, `text`, `options: string[]` of length 4, `correctIndex: number`, `explanation: string`).
+- CSV mode: file input (`.csv`); columns `topicId,text,option1,option2,option3,option4,correctIndex,explanation`; parsed client-side.
+- Pre-import preview: shows count of valid rows and count of invalid rows with error details.
+- On confirm: bulk-inserts valid rows via `db.questions.bulkAdd`, enriching each with `source: 'generated'`, `errorCount: 0`, `lastSeenAt: null`, `createdAt: Date.now()`.
+- Shows a success toast (PrimeVue Toast) after import.
+
+### Routing
+- `/library` → LibraryView (lazy-loaded)
+- `/library/new` → QuestionFormView (lazy-loaded)
+- `/library/:id/edit` → QuestionFormView (lazy-loaded)
+- No nav guard needed for Library routes.
+
+### Navigation
+- BottomNav gains a fifth tab: "Library" linking to `/library`.
+
+### Data Layer
+- No schema changes to Dexie. All operations use the existing `questions` table.
+- Key operations: `db.questions.toArray()`, `db.questions.get(id)`, `db.questions.add(q)`, `db.questions.update(id, changes)`, `db.questions.delete(id)`, `db.questions.bulkAdd(qs)`.
+- Topic list for the dropdown sourced from `db.topics.toArray()`.
+
+### Architecture Decisions
+- No new Pinia store — Library views read/write Dexie directly (same pattern used sparingly elsewhere for one-off operations).
+- CSV parsing is done with a simple client-side split (no third-party CSV library); the format is strict and controlled by the user.
+- Import validation is synchronous and runs entirely in the browser before any DB write.
+- Deleting a question does not cascade to sessions (session records store a snapshot of answers, not live question references).
+
+## Testing Decisions
+
+A good test only asserts external behavior observable through the module's public interface — not internal state or implementation details.
+
+**ImportDialog validation logic**
+- Unit-test the JSON validation function: valid input → parsed array; missing field → error; wrong `options` length → error; non-numeric `correctIndex` → error.
+- Unit-test the CSV parser: valid file → parsed array matching expected shape; missing column → error row reported.
+
+**QuestionFormView (integration)**
+- Test add mode: submitting a valid form calls `db.questions.add` with the correct shape and navigates to `/library`.
+- Test edit mode: form is pre-populated from DB record; submitting calls `db.questions.update` with changed fields only.
+- Test validation: submitting with a missing required field does not call DB and shows an error.
+
+**LibraryView (integration)**
+- Test delete: clicking delete and confirming calls `db.questions.delete(id)` and removes the item from the rendered list.
+- Test filter: selecting a topic shows only questions matching that `topicId`.
+
+Prior art for integration tests: existing tests in `src/views/__tests__/` using a seeded in-memory Dexie instance (`fake-indexeddb`).
+
+## Out of Scope
+
+- In-app AI question generation (no API key, no in-app calls to Anthropic).
+- Remote/cloud database or sync across devices.
+- Bulk delete (select multiple questions and delete at once).
+- Question tagging or custom categories beyond the existing `topicId` field.
+- Question search by free text (filter by topic only for now).
+- Import format negotiation or auto-detection (user selects JSON or CSV explicitly).
+- Export questions from the app to a file.
+- Question deduplication on import.
+- Reordering questions manually.
+- Pagination or virtual scrolling (acceptable for a personal question bank of a few hundred questions).
+
+## Further Notes
+
+- The expected JSON import shape matches the existing seed format exactly, making it easy for users to generate compatible output by sharing the seed structure with Claude.ai as a reference.
+- CSV column order is fixed (`topicId,text,option1,option2,option3,option4,correctIndex,explanation`) and should be documented in the import dialog's placeholder/helper text so users know how to format their spreadsheet.
+- The `correctIndex` field is zero-based (0 = option1, 3 = option4); this should be made explicit in the import UI to avoid off-by-one errors.
+- Deleting seed questions is allowed — there is no protection on `source: 'seed'` records. If the user deletes all questions for a topic, that topic will simply return zero questions in study sessions.

--- a/docs/QUESTION_LIBRARY_04/RUNBOOK.md
+++ b/docs/QUESTION_LIBRARY_04/RUNBOOK.md
@@ -1,0 +1,322 @@
+# RUNBOOK: Question Library — Issue Wave Execution
+
+Drives all 6 GitHub issues via dependency-ordered waves. Each wave spawns
+isolated agents that implement features, then open PRs for review.
+
+**Rule:** Merge all PRs in wave N before starting wave N+1.
+
+---
+
+## Dependency Wave Map
+
+| Wave | Issues | Parallel | Blocked by |
+|------|--------|----------|------------|
+| 1 | #60 | — | — |
+| 2 | #61, #62, #64 | ✓ | #60 |
+| 3 | #63, #65 | ✓ | #62, #64 (respectively) |
+
+---
+
+## How to use
+
+1. Copy a prompt block below
+2. Paste into your Claude Code session and press Enter
+3. Claude spawns an isolated agent with its own git worktree
+4. The agent implements the feature and opens a PR
+5. Review and merge the PR, then move to the next wave
+
+---
+
+## Wave 1 — #60: Library tab scaffolding and question list
+
+**Prerequisite:** None
+
+```
+Spawn an agent with isolation: "worktree" to implement GitHub issue #60.
+
+Branch: issue/60  |  PR target: main
+
+== ISSUE: feat(library): library tab scaffolding and question list with topic filter ==
+
+What to build:
+Add a "Library" tab to BottomNav.vue linking to /library. Add the /library
+route (lazy-loaded) to the router. Create LibraryView.vue at /library.
+
+LibraryView:
+- Page layout: <main class="library-view">, <header class="library-view__header"><h1>Library</h1></header>
+- BEM + SCSS with nesting, CSS custom properties (--color-*, --space-*, --radius-*)
+- Load all questions from db.questions on mount using a ref + onMounted
+- Load all topics from db.topics on mount for the filter chips
+- Topic filter chips above the list; selecting one filters the visible questions
+- "All" chip selected by default (shows everything)
+- Each question card shows: topic badge (topicId), truncated question text (max 2 lines), Edit button (navigates to /library/:id/edit), Delete button (placeholder, just logs for now)
+- Header shows total question count and per-topic count in a subtitle
+- Empty state message when no questions match the active filter
+- "Add question" button in header navigating to /library/new (placeholder route is fine)
+- "Import" button in header (placeholder, does nothing yet)
+
+Acceptance criteria:
+- Bottom nav has a "Library" tab that navigates to /library
+- LibraryView renders all questions on load
+- Selecting a topic chip filters the list to that topic only
+- "All" chip resets the filter
+- Each question card shows topic badge and truncated text
+- Edit button on each card navigates to /library/:id/edit
+- Total question count visible in the view
+- Empty state shown when filter yields no results
+- No TypeScript errors
+
+PRD context: docs/QUESTION_LIBRARY_04/PRD.md
+
+Instructions:
+1. Create branch issue/60 from main
+2. Implement the feature following the code patterns in the existing views (BEM, SCSS nesting, PrimeVue components, @/ path aliases, TypeScript)
+3. Open a PR to main titled: feat(library): library tab scaffolding and question list with topic filter
+4. Include "Closes #60" in the PR body
+```
+
+---
+
+## Wave 2 — #61, #62, #64 (run in parallel)
+
+**Prerequisite:** #60 merged
+
+### #61: Delete question with confirmation
+
+```
+Spawn an agent with isolation: "worktree" to implement GitHub issue #61.
+
+Branch: issue/61  |  PR target: main
+
+== ISSUE: feat(library): delete question with confirmation ==
+
+What to build:
+Wire up the Delete button on each question card in LibraryView.
+Use PrimeVue ConfirmDialog (or a simple Dialog) to ask for confirmation before
+deleting. On confirm: call db.questions.delete(id), remove the item from the
+local reactive list, show a success toast via useToast(). On cancel: do nothing.
+
+Acceptance criteria:
+- Delete button on each question card opens a confirmation dialog
+- Confirming calls db.questions.delete(id) and removes the card from the list
+- Cancelling the dialog leaves the question untouched
+- Success toast shown after deletion
+- No TypeScript errors
+
+PRD context: docs/QUESTION_LIBRARY_04/PRD.md
+
+Instructions:
+1. Create branch issue/61 from main (ensure #60 is merged first)
+2. Implement following existing patterns (BEM, SCSS, PrimeVue, TypeScript)
+3. Open a PR to main titled: feat(library): delete question with confirmation
+4. Include "Closes #61" in the PR body
+```
+
+### #62: Add question form
+
+```
+Spawn an agent with isolation: "worktree" to implement GitHub issue #62.
+
+Branch: issue/62  |  PR target: main
+
+== ISSUE: feat(library): add question form ==
+
+What to build:
+Create QuestionFormView.vue used for add mode at /library/new.
+Wire the "Add question" header button in LibraryView to navigate to /library/new.
+Add the /library/new route (lazy-loaded) to the router.
+
+QuestionFormView (add mode):
+- Page layout: <main class="question-form-view">, header with back button + "New Question" title
+- Topic: PrimeVue Select (dropdown), options loaded from db.topics.toArray() on mount, display topic name, value is topicId
+- Question text: PrimeVue Textarea (autoResize)
+- Options A–D: four InputText fields labeled A, B, C, D
+- Correct answer: PrimeVue RadioButton group, one per option (A/B/C/D)
+- Explanation: PrimeVue Textarea (autoResize)
+- Save button: validates all fields non-empty, inserts via db.questions.add({
+    topicId, text, options: [optA, optB, optC, optD],
+    correctIndex, explanation,
+    source: 'generated', errorCount: 0, lastSeenAt: null, createdAt: Date.now()
+  }), navigates back to /library
+- Cancel button: navigates back to /library without saving
+- Show inline validation errors on required fields if Save is attempted with empty fields
+
+Acceptance criteria:
+- /library/new renders the blank form
+- Topic dropdown populated from db.topics
+- All fields present and correctly typed
+- Submitting with any empty field shows validation error, does not write to DB
+- Valid submission inserts question and navigates to /library
+- New question visible in LibraryView after return
+- Cancel returns to /library without inserting
+- No TypeScript errors
+
+PRD context: docs/QUESTION_LIBRARY_04/PRD.md
+
+Instructions:
+1. Create branch issue/62 from main (ensure #60 is merged first)
+2. Implement following existing patterns (BEM, SCSS, PrimeVue, TypeScript)
+3. Open a PR to main titled: feat(library): add question form
+4. Include "Closes #62" in the PR body
+```
+
+### #64: JSON import via paste dialog
+
+```
+Spawn an agent with isolation: "worktree" to implement GitHub issue #64.
+
+Branch: issue/64  |  PR target: main
+
+== ISSUE: feat(library): JSON import via paste dialog ==
+
+What to build:
+Wire up the "Import" button in LibraryView to open a PrimeVue Dialog.
+The dialog has a JSON tab (CSV tab comes in the next issue — leave a tab
+placeholder or a toggle for it, but only implement JSON for now).
+
+JSON import flow:
+1. User pastes a JSON array into a Textarea
+2. "Preview" button (or auto-preview on paste) parses and validates the JSON
+3. Validation rules per item:
+   - topicId: non-empty string
+   - text: non-empty string
+   - options: array of exactly 4 non-empty strings
+   - correctIndex: integer 0–3
+   - explanation: non-empty string
+4. Show a preview summary: "X valid questions, Y invalid" with error details
+   (item index + which field failed) for invalid items
+5. "Import X questions" confirm button: calls db.questions.bulkAdd on valid items,
+   enriching each with source: 'generated', errorCount: 0, lastSeenAt: null,
+   createdAt: Date.now()
+6. On success: close dialog, reload question list, show success toast
+7. If 0 valid items: confirm button is disabled, show error message
+
+Helper text in dialog should show the expected JSON shape:
+[{ "topicId": "ec2", "text": "...", "options": ["A","B","C","D"], "correctIndex": 0, "explanation": "..." }]
+
+Acceptance criteria:
+- "Import" button opens the dialog
+- Pasting valid JSON shows correct preview count
+- Pasting JSON with invalid items shows per-item error details
+- Confirming inserts only valid items into DB
+- Questions appear in LibraryView after import without page reload
+- Success toast shows number of questions imported
+- Pasting an empty string or invalid JSON shows a parse error
+- Import button disabled when 0 valid items
+- No TypeScript errors
+
+PRD context: docs/QUESTION_LIBRARY_04/PRD.md
+
+Instructions:
+1. Create branch issue/64 from main (ensure #60 is merged first)
+2. Implement following existing patterns (BEM, SCSS, PrimeVue, TypeScript)
+3. Open a PR to main titled: feat(library): JSON import via paste dialog
+4. Include "Closes #64" in the PR body
+```
+
+---
+
+## Wave 3 — #63, #65 (run in parallel)
+
+**Prerequisite:** #62 merged (for #63), #64 merged (for #65)
+
+### #63: Edit existing question
+
+```
+Spawn an agent with isolation: "worktree" to implement GitHub issue #63.
+
+Branch: issue/63  |  PR target: main
+
+== ISSUE: feat(library): edit existing question ==
+
+What to build:
+Extend QuestionFormView.vue to support edit mode at /library/:id/edit.
+Add the /library/:id/edit route (lazy-loaded) to the router.
+Wire the Edit button on each question card in LibraryView to navigate to
+/library/:id/edit.
+
+Edit mode behavior:
+- Detect edit mode from useRoute().params.id being present
+- On mount: load question via db.questions.get(Number(id)) and pre-populate all form fields
+- If the question ID does not exist, navigate back to /library and show an error toast
+- Save: call db.questions.update(id, { topicId, text, options, correctIndex, explanation }),
+  navigate back to /library
+- Page title in header: "Edit Question"
+- Same validation as add mode — all fields required
+
+Acceptance criteria:
+- Edit button on each card in LibraryView navigates to /library/:id/edit
+- All form fields pre-populated with existing question data
+- Saving writes updated values to DB and navigates to /library
+- Updated question reflected in LibraryView on return
+- Invalid id redirects to /library with error toast
+- Cancel returns to /library without saving
+- No TypeScript errors
+
+PRD context: docs/QUESTION_LIBRARY_04/PRD.md
+
+Instructions:
+1. Create branch issue/63 from main (ensure #62 is merged first)
+2. Implement following existing patterns (BEM, SCSS, PrimeVue, TypeScript)
+3. Open a PR to main titled: feat(library): edit existing question
+4. Include "Closes #63" in the PR body
+```
+
+### #65: CSV import via file upload
+
+```
+Spawn an agent with isolation: "worktree" to implement GitHub issue #65.
+
+Branch: issue/65  |  PR target: main
+
+== ISSUE: feat(library): CSV import via file upload ==
+
+What to build:
+Extend the import dialog from #64 with a CSV tab (second tab alongside the
+existing JSON tab).
+
+CSV format (fixed column order, header row required):
+topicId,text,option1,option2,option3,option4,correctIndex,explanation
+
+CSV import flow:
+1. File input accepting .csv files only
+2. On file selection: read file client-side (FileReader), parse rows manually
+   (split by newline, split by comma — assume no embedded commas/quotes for now)
+3. Skip the header row; parse each data row into the Question shape
+4. Apply the same validation rules as JSON import
+5. Show same preview summary (valid count, invalid rows with row number + error)
+6. On confirm: db.questions.bulkAdd with same runtime fields
+7. Show success toast
+
+Helper text in the CSV tab:
+- Expected columns: topicId,text,option1,option2,option3,option4,correctIndex,explanation
+- correctIndex is zero-based (0 = option1, 3 = option4)
+
+Acceptance criteria:
+- Import dialog has a CSV tab alongside JSON tab
+- File input accepts only .csv files
+- Valid CSV produces correct preview count
+- Invalid rows reported with row number and field that failed
+- Confirming inserts valid rows into DB
+- Success toast shows number imported
+- Helper text explains column order and zero-based correctIndex
+- No TypeScript errors
+
+PRD context: docs/QUESTION_LIBRARY_04/PRD.md
+
+Instructions:
+1. Create branch issue/65 from main (ensure #64 is merged first)
+2. Implement following existing patterns (BEM, SCSS, PrimeVue, TypeScript)
+3. Open a PR to main titled: feat(library): CSV import via file upload
+4. Include "Closes #65" in the PR body
+```
+
+---
+
+## Quick reference
+
+| Wave | Paste N prompts | Merge PRs | Then |
+|------|----------------|-----------|------|
+| 1 | 1 | #60 | → wave 2 |
+| 2 | 3 simultaneously | #61, #62, #64 | → wave 3 |
+| 3 | 2 simultaneously | #63, #65 | done |

--- a/docs/QUESTION_LIBRARY_04/TRACKER.md
+++ b/docs/QUESTION_LIBRARY_04/TRACKER.md
@@ -1,0 +1,12 @@
+# Question Library — Issue Tracker
+
+Parent PRD: #59
+
+| # | Issue | Type | Blocked by | User stories |
+|---|-------|------|------------|--------------|
+| 1 | [#60 Library tab scaffolding and question list](https://github.com/jayfalconiii/exam-creator/issues/60) | AFK | None | 1, 2, 3, 4, 20 |
+| 2 | [#61 Delete question with confirmation](https://github.com/jayfalconiii/exam-creator/issues/61) | AFK | #60 | 7, 8 |
+| 3 | [#62 Add question form](https://github.com/jayfalconiii/exam-creator/issues/62) | AFK | #60 | 9, 10, 11, 12 |
+| 4 | [#63 Edit existing question](https://github.com/jayfalconiii/exam-creator/issues/63) | AFK | #62 | 5, 6 |
+| 5 | [#64 JSON import via paste dialog](https://github.com/jayfalconiii/exam-creator/issues/64) | AFK | #60 | 13, 14, 16, 17, 18, 19 |
+| 6 | [#65 CSV import via file upload](https://github.com/jayfalconiii/exam-creator/issues/65) | AFK | #64 | 15, 16, 17, 18, 19 |


### PR DESCRIPTION
## 🚀 Feature
- Adds planning docs for the Question Library feature (#59).

### 📄 Summary
- Introduces `docs/QUESTION_LIBRARY_04/` with three documents covering the full scope of the question management tab.

Closes #59

### 🌟 What's New
- `PRD.md` — problem statement, 20 user stories, implementation decisions, testing decisions, and out-of-scope items
- `TRACKER.md` — dependency table linking all 6 GitHub issues (#60–#65) to user stories
- `RUNBOOK.md` — copy-paste wave execution guide for spawning isolated agents per issue

### 🧪 How to Test
- Read `docs/QUESTION_LIBRARY_04/PRD.md` and verify it accurately reflects the agreed scope
- Read `TRACKER.md` and confirm all 6 issues are linked correctly
- Read `RUNBOOK.md` and confirm wave ordering matches issue dependencies

### 📌 Checklist
- [x] Feature works as expected
- [x] Updated relevant documentation