### PR TITLE
feat(library): JSON import via paste dialog

### DIFF
--- a/src/views/LibraryView.vue
+++ b/src/views/LibraryView.vue
@@ -151,7 +151,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, toRaw } from 'vue'
 import { useRouter } from 'vue-router'
 import Button from 'primevue/button'
 import { useConfirm } from 'primevue/useconfirm'
@@ -327,7 +327,7 @@ function closeDialog() {
 async function handleImport() {
   if (!previewResult.value || previewResult.value.valid.length === 0) return
 
-  const toInsert = previewResult.value.valid.map((q) => JSON.parse(JSON.stringify(q)))
+  const toInsert = previewResult.value.valid.map((q) => toRaw(q))
   await db.questions.bulkAdd(toInsert as Question[])
 
   questions.value = await db.questions.toArray()


### PR DESCRIPTION
## 🚀 Feature
- Add JSON paste import dialog to LibraryView

### 📄 Summary
- Wires up the Import button in LibraryView to open a PrimeVue Dialog with a JSON tab (CSV tab placeholder included, disabled).
- User pastes a JSON array, clicks Preview to validate, sees valid/invalid counts with per-item field errors, then confirms to bulk-insert valid questions into the DB.

Closes #64

### 🌟 What's New
- Import button opens a Dialog with JSON tab
- Textarea for pasting JSON array
- Preview button validates each item against required fields (topicId, text, options[4], correctIndex 0-3, explanation)
- Preview summary shows valid/invalid counts and per-item error details
- Confirm button calls `db.questions.bulkAdd` with enriched valid items (`source: 'generated'`, `errorCount: 0`, `lastSeenAt: null`, `createdAt: Date.now()`)
- Questions list reloads after import without page navigation
- Success toast displays number of questions imported
- Import button disabled when 0 valid items
- Parse errors shown for empty input, invalid JSON, and non-array input

### 🧪 How to Test
- Navigate to Library view
- Click "Import" button — dialog should open
- Paste valid JSON array, click Preview — should show correct count
- Paste JSON with invalid items — should show per-item field errors
- Click Import — questions should appear in the list and a success toast fires
- Paste empty string or bad JSON — parse error message appears
- With 0 valid items, Import button should be disabled

### 🖼️ UI Changes (if any)
- New import dialog with JSON/CSV tabs, textarea, preview section, and footer action buttons

### 📌 Checklist
- [ ] Feature works as expected
- [ ] No TypeScript errors
- [ ] Build passes