### PR TITLE
feat(library): edit existing question

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -15,7 +15,7 @@ const router = createRouter({
     { path: '/settings', component: () => import('@/views/SettingsView.vue') },
     { path: '/library', component: () => import('@/views/LibraryView.vue') },
     { path: '/library/new', component: () => import('@/views/QuestionFormView.vue') },
-    { path: '/library/:id/edit', component: () => import('@/views/LibraryView.vue') },
+    { path: '/library/:id/edit', component: () => import('@/views/QuestionFormView.vue') },
   ],
 })
 

--- a/src/views/QuestionFormView.vue
+++ b/src/views/QuestionFormView.vue
@@ -4,7 +4,7 @@
       <button class="question-form-view__back-btn" @click="router.push('/library')">
         ← Back
       </button>
-      <h1 class="question-form-view__title">New Question</h1>
+      <h1 class="question-form-view__title">{{ isEditMode ? 'Edit Question' : 'New Question' }}</h1>
     </header>
 
     <form class="question-form-view__form" @submit.prevent="handleSave">
@@ -99,8 +99,8 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
-import { useRouter } from 'vue-router'
+import { ref, computed, onMounted } from 'vue'
+import { useRouter, useRoute } from 'vue-router'
 import Select from 'primevue/select'
 import Textarea from 'primevue/textarea'
 import InputText from 'primevue/inputtext'
@@ -111,7 +111,10 @@ import { db } from '@/db/db'
 import type { Topic } from '@/types'
 
 const router = useRouter()
+const route = useRoute()
 const toast = useToast()
+
+const isEditMode = computed(() => !!route.params.id)
 
 const topics = ref<Topic[]>([])
 const topicId = ref<string>('')
@@ -125,6 +128,21 @@ const errors = ref<Record<string, string>>({})
 
 onMounted(async () => {
   topics.value = await db.topics.toArray()
+
+  if (isEditMode.value) {
+    const id = Number(route.params.id)
+    const question = await db.questions.get(id)
+    if (!question) {
+      toast.add({ severity: 'error', summary: 'Not found', detail: 'Question not found.', life: 3000 })
+      router.push('/library')
+      return
+    }
+    topicId.value = question.topicId
+    text.value = question.text
+    options.value = [...question.options]
+    correctIndex.value = question.correctIndex
+    explanation.value = question.explanation
+  }
 })
 
 function validate(): boolean {
@@ -140,18 +158,32 @@ function validate(): boolean {
 
 async function handleSave() {
   if (!validate()) return
-  await db.questions.add({
-    topicId: topicId.value,
-    text: text.value.trim(),
-    options: options.value.map((o) => o.trim()),
-    correctIndex: correctIndex.value as number,
-    explanation: explanation.value.trim(),
-    source: 'generated',
-    errorCount: 0,
-    lastSeenAt: null,
-    createdAt: Date.now(),
-  })
-  toast.add({ severity: 'success', summary: 'Question added', detail: 'Your question has been saved.', life: 3000 })
+
+  if (isEditMode.value) {
+    const id = Number(route.params.id)
+    await db.questions.update(id, {
+      topicId: topicId.value,
+      text: text.value.trim(),
+      options: options.value.map((o) => o.trim()),
+      correctIndex: correctIndex.value as number,
+      explanation: explanation.value.trim(),
+    })
+    toast.add({ severity: 'success', summary: 'Question updated', detail: 'Changes saved.', life: 3000 })
+  } else {
+    await db.questions.add({
+      topicId: topicId.value,
+      text: text.value.trim(),
+      options: options.value.map((o) => o.trim()),
+      correctIndex: correctIndex.value as number,
+      explanation: explanation.value.trim(),
+      source: 'generated',
+      errorCount: 0,
+      lastSeenAt: null,
+      createdAt: Date.now(),
+    })
+    toast.add({ severity: 'success', summary: 'Question added', detail: 'Your question has been saved.', life: 3000 })
+  }
+
   router.push('/library')
 }
 </script>


### PR DESCRIPTION
## 🚀 Feature
- Extend QuestionFormView to support edit mode at /library/:id/edit

### 📄 Summary
- Fixed router: `/library/:id/edit` was incorrectly mapped to `LibraryView` — now correctly maps to `QuestionFormView`
- Extended `QuestionFormView` to detect edit mode via `useRoute().params.id`
- Pre-populates all fields on mount from DB in edit mode
- Invalid ID redirects to `/library` with an error toast
- Save in edit mode calls `db.questions.update()` and shows "Question updated" toast

Closes #63

### 🌟 What's New
- Edit button on library cards navigates to `/library/:id/edit` (was already wired correctly in `LibraryView`)
- `QuestionFormView` handles both add and edit modes
- Page title shows "Edit Question" in edit mode
- Saving in edit mode persists changes to Dexie and navigates back to `/library`

### 🧪 How to Test
- Navigate to Library, click Edit on any question
- Verify all fields are pre-populated
- Modify fields and click Save — confirm changes are reflected in Library
- Navigate to `/library/99999/edit` (non-existent ID) — should redirect to `/library` with error toast
- Click Cancel — should return to `/library` without saving

### 📌 Checklist
- [ ] Feature works as expected
- [ ] No TypeScript errors
- [ ] Build passes