### PR TITLE
fix(ui): disable double-tap zoom on mobile

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -43,6 +43,7 @@ body {
 body {
   margin: 0;
   font-family: 'Inter', system-ui, -apple-system, sans-serif;
+  touch-action: manipulation;
 }
 
 #app {


### PR DESCRIPTION
## 🚀 Feature
- Prevents accidental zoom when double-tapping on mobile devices.

### 📄 Summary
- Added `touch-action: manipulation` to the `body` element in `App.vue`.

### 🌟 What's New
- Double-tap zoom is disabled app-wide on mobile while pinch-to-zoom remains functional.

### 🧪 How to Test
- Open the app on a mobile device or browser devtools mobile emulation
- Double-tap anywhere on the screen — should not zoom in
- Pinch-to-zoom should still work

### 📌 Checklist
- [x] Feature works as expected
- [x] No unit tests needed (CSS-only change)