### PR TITLE
feat(library): duplicate question detection

### DIFF
--- a/src/views/LibraryView.vue
+++ b/src/views/LibraryView.vue
@@ -63,7 +63,7 @@
         <header class="library-view__card-header">
           <div class="library-view__card-badges">
             <span class="library-view__badge">{{ question.topicId }}</span>
-            <span v-if="duplicateIds.has(question.id!)" class="library-view__badge library-view__badge--duplicate">Duplicate</span>
+            <span v-if="duplicateIds.has(question.id!)" class="library-view__badge library-view__badge--duplicate">Duplicate {{ duplicateIds.get(question.id!) }}%</span>
           </div>
           <div class="library-view__card-actions">
             <Button
@@ -265,8 +265,8 @@ function diceCoefficient(a: string, b: string): number {
   return (2 * matches) / (biA.length + biB.length)
 }
 
-const duplicateIds = computed((): Set<number> => {
-  const ids = new Set<number>()
+const duplicateIds = computed((): Map<number, number> => {
+  const ids = new Map<number, number>()
   const byTopic = new Map<string, Question[]>()
   for (const q of questions.value) {
     if (!byTopic.has(q.topicId)) byTopic.set(q.topicId, [])
@@ -275,9 +275,13 @@ const duplicateIds = computed((): Set<number> => {
   for (const group of byTopic.values()) {
     for (let i = 0; i < group.length; i++) {
       for (let j = i + 1; j < group.length; j++) {
-        if (diceCoefficient(group[i].text, group[j].text) >= 0.7) {
-          ids.add(group[i].id!)
-          ids.add(group[j].id!)
+        const score = diceCoefficient(group[i].text, group[j].text)
+        if (score >= 0.7) {
+          const pct = Math.round(score * 100)
+          const idI = group[i].id!
+          const idJ = group[j].id!
+          ids.set(idI, Math.max(ids.get(idI) ?? 0, pct))
+          ids.set(idJ, Math.max(ids.get(idJ) ?? 0, pct))
         }
       }
     }


### PR DESCRIPTION
## 🚀 Feature
- Adds fuzzy duplicate detection to LibraryView using Dice coefficient on normalised text.

### 📄 Summary
- Implements a `diceCoefficient` function comparing bigrams of normalised (lowercase, trimmed) question text.
- Compares all question pairs within the same `topicId`; marks both as duplicates when similarity >= 0.70.
- `duplicateIds` is a `computed` `Set<number>` — updates automatically as questions are added/deleted.

Closes #77

### 🌟 What's New
- "Duplicates" chip in the filter row — only visible when at least one duplicate pair exists.
- Selecting chip sets `activeFilter` to a sentinel value and shows only duplicate questions.
- Each card shows a "Duplicate" badge when its id is in `duplicateIds`.
- Chip and badges disappear automatically once all duplicates are resolved.

### 🧪 How to Test
- [ ] Add two questions in the same topic with nearly identical text (e.g. copy-paste with a minor word change).
- [ ] Verify "Duplicates" chip appears in the filter row.
- [ ] Click chip — list should show only those questions, each with a "Duplicate" badge.
- [ ] Delete one of the duplicates — chip and badges should disappear.
- [ ] Add identical questions under different topics — they should NOT be flagged as duplicates.

### 🖼️ UI Changes (if any)
- "Duplicates" chip added at the end of the filter row (warning colour).
- "Duplicate" badge appears alongside the topic badge on affected cards.

### 📌 Checklist
- [x] Feature works as expected
- [ ] Unit/integration tests added (if applicable)
- [x] Updated relevant documentation
- [ ] Verified in staging (if applicable)