### PR TITLE
refactor(topics): remove COLOR_MAP from TopicTile, read topic.color from DB

### DIFF
--- a/src/components/TopicTile.vue
+++ b/src/components/TopicTile.vue
@@ -2,7 +2,7 @@
   <RouterLink
     :to="`/topics/${topic.topicId}`"
     class="topic-tile"
-    :style="{ backgroundColor: tileColor }"
+    :style="{ backgroundColor: topic.color ?? '#78716c' }"
   >
     <span class="topic-tile__name">{{ topic.name }}</span>
     <span class="topic-tile__score">{{ Math.round(topic.effectiveScore) }}%</span>
@@ -10,32 +10,9 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
 import type { TopicWithScore } from '@/stores/topics'
 
-const props = defineProps<{ topic: TopicWithScore }>()
-
-const COLOR_MAP: Record<string, string> = {
-  'ec2':             '#1565c0',
-  's3':              '#00695c',
-  'vpc':             '#6a1b9a',
-  'iam':             '#c62828',
-  'rds':             '#283593',
-  'lambda':          '#ad1457',
-  'cloudfront':      '#00838f',
-  'route53':         '#4e342e',
-  'elb':             '#2e7d32',
-  'dynamodb':        '#4527a0',
-  'sqs-sns':         '#e65100',
-  'cloudwatch':      '#37474f',
-  'efs-fsx':         '#0277bd',
-  'glacier':         '#4a148c',
-  'kms-secrets':     '#b71c1c',
-  'trusted-advisor': '#1b5e20',
-  'storage-gateway': '#0d47a1',
-}
-
-const tileColor = computed(() => COLOR_MAP[props.topic.topicId] ?? '#78716c')
+defineProps<{ topic: TopicWithScore }>()
 </script>
 
 <style scoped lang="scss">


### PR DESCRIPTION
## 🚀 Feature
- Remove hardcoded \`COLOR_MAP\` from \`TopicTile.vue\` and read tile background color directly from \`topic.color\` stored in the DB.

### 📄 Summary
- \`TopicTile.vue\` previously maintained a static \`COLOR_MAP\` keyed by \`topicId\` to determine tile background colors. Since issue #88 added a \`color\` field to the \`Topic\` type and seeds it per-topic in the DB, the map is now redundant. This PR removes it and binds \`backgroundColor\` directly to \`topic.color\` (with fallback \`#78716c\`).

Closes #90

### 🌟 What's New
- \`COLOR_MAP\` const removed from \`TopicTile.vue\`
- \`tileColor\` computed removed; \`backgroundColor\` bound directly to \`topic.color ?? '#78716c'\`
- Unused \`computed\` import removed
- \`TopicWithScore\` extends \`Topic\` which already includes \`color: string\` — no type changes needed

### 🧪 How to Test
- Run the app locally and verify all 17 topic tiles render with their expected colors
- Confirm topics without a \`color\` value render with fallback \`#78716c\`
- Run \`npx vue-tsc --noEmit\` — expect no TypeScript errors

### 🖼️ UI Changes (if any)
- No visual changes expected; tile colors remain identical since DB seeds the same hex values previously in \`COLOR_MAP\`

### 📌 Checklist
- [ ] Feature works as expected
- [ ] Unit/integration tests added (if applicable)
- [ ] Updated relevant documentation
- [ ] Verified in staging (if applicable)