### PR TITLE
feat(backup): implement Merge import path

### DIFF
--- a/src/__tests__/backup.spec.ts
+++ b/src/__tests__/backup.spec.ts
@@ -1,6 +1,6 @@
 import 'fake-indexeddb/auto'
 import { describe, it, expect, beforeEach } from 'vitest'
-import { detectBackupFormat, buildBackup } from '@/utils/backup'
+import { detectBackupFormat, buildBackup, mergeBackup } from '@/utils/backup'
 
 describe('detectBackupFormat', () => {
   it("returns 'backup' for object with version:1, questions, topics", () => {
@@ -71,5 +71,150 @@ describe('buildBackup', () => {
     expect(result.topics).toHaveLength(1)
     expect(result.topics[0]).not.toHaveProperty('id')
     expect(result.topics[0].name).toBe('EC2')
+  })
+})
+
+const baseQuestion = {
+  options: ['A', 'B', 'C', 'D'],
+  correctIndex: 0,
+  explanation: 'x',
+  source: 'seed' as const,
+  lastSeenAt: null,
+  createdAt: Date.now(),
+}
+
+const baseTopic = {
+  color: '#000',
+  rawScore: 0,
+  lastReviewedAt: null,
+  totalSessions: 0,
+}
+
+describe('mergeBackup', () => {
+  beforeEach(async () => {
+    const { db } = await import('@/db/db')
+    await db.questions.clear()
+    await db.topics.clear()
+  })
+
+  it('keeps higher errorCount for overlapping questions (questions scope)', async () => {
+    const { db } = await import('@/db/db')
+    await db.questions.add({ ...baseQuestion, topicId: 'ec2', text: 'What is EC2?', errorCount: 3 })
+
+    const backup = {
+      version: 1 as const,
+      questions: [{ ...baseQuestion, topicId: 'ec2', text: 'What is EC2?', errorCount: 7 }],
+      topics: [],
+    }
+
+    await mergeBackup(backup, 'questions')
+
+    const all = await db.questions.toArray()
+    expect(all).toHaveLength(1)
+    expect(all[0].errorCount).toBe(7)
+  })
+
+  it('keeps local errorCount when it is higher', async () => {
+    const { db } = await import('@/db/db')
+    await db.questions.add({ ...baseQuestion, topicId: 'ec2', text: 'What is EC2?', errorCount: 10 })
+
+    const backup = {
+      version: 1 as const,
+      questions: [{ ...baseQuestion, topicId: 'ec2', text: 'What is EC2?', errorCount: 2 }],
+      topics: [],
+    }
+
+    await mergeBackup(backup, 'questions')
+
+    const all = await db.questions.toArray()
+    expect(all).toHaveLength(1)
+    expect(all[0].errorCount).toBe(10)
+  })
+
+  it('inserts new questions that do not exist locally', async () => {
+    const { db } = await import('@/db/db')
+
+    const backup = {
+      version: 1 as const,
+      questions: [{ ...baseQuestion, topicId: 'ec2', text: 'New question', errorCount: 0 }],
+      topics: [],
+    }
+
+    await mergeBackup(backup, 'questions')
+
+    const all = await db.questions.toArray()
+    expect(all).toHaveLength(1)
+    expect(all[0].text).toBe('New question')
+  })
+
+  it('questions-only scope leaves topics table untouched', async () => {
+    const { db } = await import('@/db/db')
+    await db.topics.add({ ...baseTopic, topicId: 'local', name: 'Local' })
+
+    const backup = {
+      version: 1 as const,
+      questions: [],
+      topics: [{ ...baseTopic, topicId: 'backup-topic', name: 'Backup Topic' }],
+    }
+
+    await mergeBackup(backup, 'questions')
+
+    const allTopics = await db.topics.toArray()
+    expect(allTopics).toHaveLength(1)
+    expect(allTopics[0].topicId).toBe('local')
+  })
+
+  it('questions-and-scores scope inserts new topics, keeps existing ones unchanged', async () => {
+    const { db } = await import('@/db/db')
+    await db.topics.add({ ...baseTopic, topicId: 'ec2', name: 'EC2 Local', rawScore: 5 })
+
+    const backup = {
+      version: 1 as const,
+      questions: [],
+      topics: [
+        { ...baseTopic, topicId: 'ec2', name: 'EC2 Backup', rawScore: 99 },
+        { ...baseTopic, topicId: 's3', name: 'S3', rawScore: 3 },
+      ],
+    }
+
+    await mergeBackup(backup, 'questions-and-scores')
+
+    const allTopics = await db.topics.toArray()
+    expect(allTopics).toHaveLength(2)
+
+    const ec2 = allTopics.find((t) => t.topicId === 'ec2')
+    expect(ec2?.name).toBe('EC2 Local')
+    expect(ec2?.rawScore).toBe(5)
+
+    const s3 = allTopics.find((t) => t.topicId === 's3')
+    expect(s3).toBeDefined()
+    expect(s3?.name).toBe('S3')
+  })
+
+  it('no duplicate questions after merge with overlapping data', async () => {
+    const { db } = await import('@/db/db')
+    await db.questions.add({ ...baseQuestion, topicId: 'ec2', text: 'What is EC2?', errorCount: 1 })
+    await db.questions.add({ ...baseQuestion, topicId: 'ec2', text: 'What is S3?', errorCount: 0 })
+
+    const backup = {
+      version: 1 as const,
+      questions: [
+        { ...baseQuestion, topicId: 'ec2', text: 'What is EC2?', errorCount: 5 },
+        { ...baseQuestion, topicId: 'ec2', text: 'What is Lambda?', errorCount: 0 },
+      ],
+      topics: [],
+    }
+
+    await mergeBackup(backup, 'questions')
+
+    const all = await db.questions.toArray()
+    const texts = all.map((q) => q.text)
+    expect(texts).toContain('What is EC2?')
+    expect(texts).toContain('What is S3?')
+    expect(texts).toContain('What is Lambda?')
+    expect(all).toHaveLength(3)
+
+    const ec2 = all.find((q) => q.text === 'What is EC2?')
+    expect(ec2?.errorCount).toBe(5)
   })
 })

--- a/src/utils/backup.ts
+++ b/src/utils/backup.ts
@@ -1,5 +1,7 @@
 import type { Question, Topic } from '@/types'
 
+export type BackupScope = 'questions' | 'questions-and-scores'
+
 export interface BackupFile {
   version: number
   questions: Omit<Question, 'id'>[]
@@ -19,6 +21,51 @@ export function detectBackupFormat(input: unknown): 'backup' | 'questions' | 'un
     return 'backup'
   }
   return 'unknown'
+}
+
+export async function mergeBackup(backup: BackupFile, scope: BackupScope): Promise<void> {
+  const { db } = await import('@/db/db')
+
+  // Merge questions: match on (topicId, text), keep higher errorCount, insert unmatched new
+  const localQuestions = await db.questions.toArray()
+  const localMap = new Map<string, Question>()
+  for (const q of localQuestions) {
+    localMap.set(`${q.topicId}::${q.text}`, q)
+  }
+
+  const toInsert: Omit<Question, 'id'>[] = []
+  const toUpdate: { id: number; errorCount: number }[] = []
+
+  for (const bq of backup.questions) {
+    const key = `${bq.topicId}::${bq.text}`
+    const local = localMap.get(key)
+    if (local) {
+      if (bq.errorCount > local.errorCount) {
+        toUpdate.push({ id: local.id!, errorCount: bq.errorCount })
+      }
+    } else {
+      toInsert.push(bq)
+    }
+  }
+
+  for (const { id, errorCount } of toUpdate) {
+    await db.questions.update(id, { errorCount })
+  }
+
+  if (toInsert.length > 0) {
+    await db.questions.bulkAdd(toInsert as Question[])
+  }
+
+  // Merge topics only when scope includes scores
+  if (scope === 'questions-and-scores') {
+    const localTopics = await db.topics.toArray()
+    const localTopicIds = new Set(localTopics.map((t) => t.topicId))
+
+    const newTopics = backup.topics.filter((t) => !localTopicIds.has(t.topicId))
+    if (newTopics.length > 0) {
+      await db.topics.bulkAdd(newTopics as Topic[])
+    }
+  }
 }
 
 export async function buildBackup(): Promise<BackupFile> {

--- a/src/views/LibraryView.vue
+++ b/src/views/LibraryView.vue
@@ -206,11 +206,12 @@
             <p class="import-dialog__selector-label">Strategy</p>
             <div class="import-dialog__selector-options">
               <button
-                class="import-dialog__selector-btn import-dialog__selector-btn--disabled"
+                class="import-dialog__selector-btn"
+                :class="{ 'import-dialog__selector-btn--active': backupStrategy === 'merge' }"
                 type="button"
                 data-testid="strategy-merge"
-                disabled
-              >Merge <span class="import-dialog__coming-soon">(coming soon)</span></button>
+                @click="backupStrategy = 'merge'"
+              >Merge</button>
               <button
                 class="import-dialog__selector-btn"
                 :class="{ 'import-dialog__selector-btn--active': backupStrategy === 'replace' }"
@@ -282,8 +283,7 @@
         />
         <Button
           v-if="activeImportTab === 'json' && backupPreviewResult"
-          :label="backupStrategy === 'replace' ? 'Replace & import' : 'Merge & import (coming soon)'"
-          :disabled="backupStrategy === 'merge'"
+          :label="backupStrategy === 'replace' ? 'Replace & import' : 'Merge & import'"
           @click="handleBackupImport"
         />
         <Button
@@ -308,7 +308,7 @@ import { useToast } from 'primevue/usetoast'
 import { db } from '@/db/db'
 import type { Question, Topic } from '@/types'
 import { pickTopicColor } from '@/utils/topicColors'
-import { detectBackupFormat } from '@/utils/backup'
+import { detectBackupFormat, mergeBackup } from '@/utils/backup'
 import type { BackupFile } from '@/utils/backup'
 
 const DUPLICATES_SENTINEL = '__duplicates__'
@@ -787,6 +787,19 @@ async function handleBackupImport() {
     ])
 
     toast.add({ severity: 'success', summary: 'Backup Restored', detail: 'Data replaced successfully.', life: 3000 })
+    closeDialog()
+    return
+  }
+
+  if (backupStrategy.value === 'merge') {
+    await mergeBackup(backup, backupScope.value)
+
+    ;[questions.value, topics.value] = await Promise.all([
+      db.questions.toArray(),
+      db.topics.toArray(),
+    ])
+
+    toast.add({ severity: 'success', summary: 'Backup Merged', detail: 'Data merged successfully.', life: 3000 })
     closeDialog()
   }
 }

--- a/src/views/__tests__/LibraryView.spec.ts
+++ b/src/views/__tests__/LibraryView.spec.ts
@@ -278,4 +278,78 @@ describe('LibraryView — backup import', () => {
     expect(dbTopics.some((t) => t.topicId === 'ec2')).toBe(true)
     expect(dbTopics.some((t) => t.topicId === 's3')).toBe(true)
   })
+
+  it('Merge + questions only: new questions inserted, existing topics unchanged', async () => {
+    await db.questions.bulkAdd([
+      { ...validQuestion, errorCount: 2, source: 'generated' as const, lastSeenAt: null, createdAt: Date.now() },
+    ])
+    await db.topics.bulkAdd([
+      { topicId: 'existing', name: 'Existing', color: '#000', rawScore: 0, lastReviewedAt: null, totalSessions: 0 },
+    ])
+
+    const wrapper = mountLibraryView()
+    await flushPromises()
+    await openImportAndPreview(wrapper, validBackup)
+
+    ;(document.querySelector('[data-testid="strategy-merge"]') as HTMLButtonElement)?.click()
+    await flushPromises()
+
+    const importBtn = [...document.querySelectorAll('button')].find(
+      (b) => b.textContent?.trim() === 'Merge & import',
+    )
+    importBtn!.click()
+    await flushPromises()
+    await flushPromises()
+    await flushPromises()
+
+    const dbQuestions = await db.questions.toArray()
+    expect(dbQuestions.map((q) => q.text)).toContain('What is EC2?')
+    expect(dbQuestions.map((q) => q.text)).toContain('What is S3?')
+
+    // topics untouched (questions-only scope)
+    const dbTopics = await db.topics.toArray()
+    expect(dbTopics.some((t) => t.topicId === 'existing')).toBe(true)
+    expect(dbTopics.some((t) => t.topicId === 'ec2')).toBe(false)
+    expect(dbTopics.some((t) => t.topicId === 's3')).toBe(false)
+  })
+
+  it('Merge + questions + scores: overlapping questions keep higher errorCount; new topics inserted', async () => {
+    await db.questions.bulkAdd([
+      { ...validQuestion, errorCount: 10, source: 'generated' as const, lastSeenAt: null, createdAt: Date.now() },
+    ])
+    await db.topics.bulkAdd([
+      { topicId: 'ec2', name: 'EC2 Local', color: '#000', rawScore: 99, lastReviewedAt: null, totalSessions: 0 },
+    ])
+
+    const wrapper = mountLibraryView()
+    await flushPromises()
+    await openImportAndPreview(wrapper, validBackup)
+
+    ;(document.querySelector('[data-testid="strategy-merge"]') as HTMLButtonElement)?.click()
+    await flushPromises()
+    ;(document.querySelector('[data-testid="scope-questions-and-scores"]') as HTMLButtonElement)?.click()
+    await flushPromises()
+
+    const importBtn = [...document.querySelectorAll('button')].find(
+      (b) => b.textContent?.trim() === 'Merge & import',
+    )
+    importBtn!.click()
+    await flushPromises()
+    await flushPromises()
+    await flushPromises()
+    await flushPromises()
+
+    const dbQuestions = await db.questions.toArray()
+    const ec2q = dbQuestions.find((q) => q.text === 'What is EC2?')
+    // backup has errorCount: 0 (validQuestion default), local has 10 — keep 10
+    expect(ec2q?.errorCount).toBe(10)
+
+    const dbTopics = await db.topics.toArray()
+    const ec2t = dbTopics.find((t) => t.topicId === 'ec2')
+    // local ec2 kept as-is
+    expect(ec2t?.name).toBe('EC2 Local')
+    expect(ec2t?.rawScore).toBe(99)
+    // s3 inserted from backup
+    expect(dbTopics.some((t) => t.topicId === 's3')).toBe(true)
+  })
 })


### PR DESCRIPTION
## 🚀 Feature
- Implements the Merge import strategy for backup files, wired into the scope + strategy prompt.

### 📄 Summary
- `mergeBackup(backup, scope)` added to `src/utils/backup.ts`: matches questions on `(topicId, text)`, keeps higher `errorCount`, inserts unmatched backup questions as new; for `questions-and-scores` scope, keeps existing topics and inserts only new ones from backup.
- `handleBackupImport` in `LibraryView.vue` updated to call `mergeBackup` when `strategy === 'merge'`; Merge button is now enabled in the UI.

Closes #114

### 🌟 What's New
- `src/utils/backup.ts`: added `BackupScope` type export and `mergeBackup(backup, scope)` function
- `src/views/LibraryView.vue`: Merge strategy button enabled; `handleBackupImport` now handles merge path; import updated to include `mergeBackup`
- `src/__tests__/backup.spec.ts`: 6 new unit tests for `mergeBackup` covering all acceptance criteria
- `src/views/__tests__/LibraryView.spec.ts`: 2 new integration tests for Merge + questions-only and Merge + questions-and-scores paths

### 🧪 How to Test
1. Open the app, go to Library, click Import
2. Paste a valid backup JSON with overlapping questions (same topicId + text) but different `errorCount`
3. Select strategy "Merge" and scope "Questions only"; click "Merge & import" — verify higher `errorCount` is kept, topics unchanged
4. Repeat with scope "Questions + scores" — verify existing topics kept as-is, new topics from backup inserted
5. Run `npm test` — 179 tests pass

### 🖼️ UI Changes (if any)
- The "Merge" strategy button is now active/clickable (previously disabled with "coming soon" label)
- Import button label changes to "Merge & import" when merge strategy is selected

### 📌 Checklist
- [x] Feature works as expected
- [x] Unit/integration tests added (if applicable)
- [ ] Updated relevant documentation
- [ ] Verified in staging (if applicable)
